### PR TITLE
ci(publish): wire PyPI trusted-publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: publish
+
+# Publishes companyctx to PyPI via trusted-publisher OIDC.
+#
+# Triggered by a GitHub Release (not raw tag-push): the Releases UI
+# enforces a human speed bump (release notes, target commit) before a
+# PyPI push. The `publish` job is gated on the `pypi` GitHub Environment
+# — configure at least one required reviewer there.
+#
+# OIDC flow: pypa/gh-action-pypi-publish exchanges the workflow's
+# short-lived OIDC token for a scoped PyPI upload credential. The claim
+# must match what PyPI's "pending publisher" form recorded:
+#   owner=dmthepm, repo=companyctx, workflow=publish.yml, env=pypi.
+# That's why this file must land on `main` before the first release.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/companyctx
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish via trusted publisher
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` — build sdist+wheel, then publish to PyPI via OIDC on `release: published`.
- Gates the publish job on a `pypi` GitHub Environment (reviewer speed bump; no long-lived PyPI token in the repo).
- Uses `pypa/gh-action-pypi-publish@release/v1` with `permissions: id-token: write`.

Closes Chunk 1 pipeline-wiring of #3. Chunk 2 (first working provider) stays out of scope here.

## Why this has to ride `main`

PyPI's pending-publisher claim is pinned to `(owner=dmthepm, repo=companyctx, workflow=publish.yml, env=pypi)`. The OIDC token emitted at release time must match that claim — so the workflow file must exist on the default branch before the first GitHub Release is cut.

## Manual steps Devon still owns (out-of-repo)

- [ ] Submit PyPI "pending publisher" form: project `companyctx`, owner `dmthepm`, repo `companyctx`, workflow `publish.yml`, environment `pypi`.
- [ ] After merge: create the `pypi` GitHub Environment in repo Settings → Environments, with Devon as a required reviewer.
- [ ] Cut a GitHub Release tagged `v0.1.0.dev0` to exercise the pipeline and reserve the PyPI name.

## Test plan

- [ ] CI passes on this PR (the new workflow has no push/PR trigger, so it only exercises existing lint/test jobs here).
- [ ] Post-merge smoke test: GitHub Release `v0.1.0.dev0` → `publish` run reaches the `pypi` environment gate → Devon approves → PyPI shows `companyctx 0.1.0.dev0`.
- [ ] `pipx install companyctx==0.1.0.dev0` resolves (CLI stubs still exit 2, as expected for M1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)