### PR TITLE
docs: reflect v0.1.0.dev0 PyPI pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0.dev0] - 2026-04-20
+
+First PyPI publish. Pre-release dev marker. Reserves the `companyctx` name
+and validates the OIDC trusted-publisher pipeline end-to-end. Every CLI
+command still exits `2` — the first working provider lands in Milestone 2.
+
 ### Added
 
+- **PyPI trusted-publisher release pipeline.** `.github/workflows/publish.yml`
+  triggers on `release: published`, builds sdist+wheel, and uploads via
+  `pypa/gh-action-pypi-publish@release/v1` using short-lived OIDC — no
+  long-lived PyPI token in the repo. The `publish` job is gated on a
+  `pypi` GitHub Environment with Devon as required reviewer; deployments
+  are restricted to `v*` tags.
 - Repo scaffolding (Milestone 1): `pyproject.toml`, package skeleton, CI, docs,
   issue/PR templates, MIT license, contributor covenant.
 - `fetch --refresh` and `fetch --from-cache` CLI stubs (surface only; behavior

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Deterministic B2B context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust.**
 
 ```bash
-pipx install companyctx          # v0.1 coming soon — see Status below
+pipx install --pip-args="--pre" companyctx   # v0.1.0.dev0 on PyPI — CLI is still stubs (see Status)
 companyctx acme-bakery.com --json
 ```
 
@@ -29,9 +29,13 @@ One site in. One schema-locked JSON object out. No API keys for the
 zero-key path. Graceful partials on anti-bot blocks. A local SQLite cache
 that compounds into a queryable B2B dataset over time.
 
-> **Status:** v0.1 in development. Not yet on PyPI. Schema + CLI surface are
-> committed in [`docs/SPEC.md`](docs/SPEC.md) and [`docs/SCHEMA.md`](docs/SCHEMA.md);
-> architecture in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+> **Status:** `v0.1.0.dev0` is on PyPI as a pre-release — name reserved,
+> OIDC publish pipeline validated. **The CLI itself is still stubs**: every
+> command exits `2`. The first working provider (`site_text_trafilatura`)
+> lands in Milestone 2, alongside a measured stealth-fetcher pick. Schema
+> + CLI surface are committed in [`docs/SPEC.md`](docs/SPEC.md) and
+> [`docs/SCHEMA.md`](docs/SCHEMA.md); architecture in
+> [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ## What this is (and isn't)
 
@@ -131,7 +135,18 @@ brief = synthesize(ctx["data"])   # your synthesis call, your prompts, your weig
 `companyctx` never calls an LLM. The brain upstream decides what the
 context means.
 
-## Install (during v0.1 dev)
+## Install
+
+Pre-release (name-reservation dev build — CLI commands are stubs that
+exit `2`; useful for pipeline wiring, not for real context yet):
+
+```bash
+pipx install --pip-args="--pre" companyctx
+companyctx --version   # companyctx 0.1.0.dev0
+companyctx --help
+```
+
+From source (recommended while M2 is in flight):
 
 ```bash
 git clone https://github.com/dmthepm/companyctx.git
@@ -140,7 +155,7 @@ pip install -e ".[dev,extract,reviews,youtube]"
 companyctx --help
 ```
 
-Once v0.1.0 ships:
+Once `v0.1.0` ships (first working provider + real `fetch`):
 
 ```bash
 pipx install companyctx


### PR DESCRIPTION
## Summary

Post-publish doc sweep — `v0.1.0.dev0` is live on PyPI, but the README and CHANGELOG were still saying "not yet on PyPI / coming soon."

- README hero: `pipx install --pip-args="--pre" companyctx` replaces the "coming soon" comment.
- README Status callout: drops the "not yet on PyPI" line; names that the CLI itself is still stubs and that real `fetch` lands in M2.
- README Install section: new pre-release block, kept from-source block for M2 work, kept the post-M2 `pipx install companyctx` block as the "real release" target.
- CHANGELOG: cuts `[0.1.0.dev0] - 2026-04-20` from the previous Unreleased section and adds the `publish.yml` + `pypi` environment as a new bullet under it.

Closes out the doc-followup side of #3 Chunk 1. Chunk 2 (first working provider) stays untouched — I'll split it into its own issue after this lands.

## Test plan

- [x] README renders: install snippet uses `--pip-args="--pre"` and matches the verified smoke test.
- [x] CHANGELOG: Keep-a-Changelog structure intact, version header + date correct.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)