### PR TITLE
docs: use 'companyctx fetch <site>' in all hero snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```bash
 pipx install --pip-args="--pre" companyctx   # v0.1.0.dev0 on PyPI — CLI is still stubs (see Status)
-companyctx acme-bakery.com --json
+companyctx fetch acme-bakery.com --json
 ```
 
 ```json
@@ -119,14 +119,14 @@ marketing.
 ## Brains-and-muscles pipe
 
 ```bash
-companyctx acme-bakery.com --json \
+companyctx fetch acme-bakery.com --json \
   | jq '.data | {site, signals, reviews}' \
   | claude -p "write a 6-section outreach brief from this context"
 ```
 
 ```python
 import json, subprocess
-ctx = json.loads(subprocess.check_output(["companyctx", "acme-bakery.com", "--json"]))
+ctx = json.loads(subprocess.check_output(["companyctx", "fetch", "acme-bakery.com", "--json"]))
 if ctx["status"] == "partial":
     print(f"heads up: {ctx['error']} — {ctx['suggestion']}")
 brief = synthesize(ctx["data"])   # your synthesis call, your prompts, your weights

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,7 +103,7 @@ committed here.
 
 ```bash
 # Brain upstream composes narrow muscles:
-companyctx acme-bakery.com --json \
+companyctx fetch acme-bakery.com --json \
   | jq '.data | {site, signals, reviews}' \
   | claude -p "write a 6-section outreach brief from this context"
 ```
@@ -112,7 +112,7 @@ Or from Python:
 
 ```python
 import json, subprocess
-ctx = json.loads(subprocess.check_output(["companyctx", "acme-bakery.com", "--json"]))
+ctx = json.loads(subprocess.check_output(["companyctx", "fetch", "acme-bakery.com", "--json"]))
 if ctx["status"] == "partial":
     print(f"heads up: {ctx['error']} — {ctx['suggestion']}")
 brief = synthesize(ctx["data"])  # your synthesis call, your prompts

--- a/docs/ZERO-KEY.md
+++ b/docs/ZERO-KEY.md
@@ -27,7 +27,7 @@ Backing that, the day-one zero-key providers:
 | `signals_site_heuristic`  | Copyright year, last blog post date, team-size claim, tech-stack fingerprint |
 
 No key required for any of these. They are the `pipx install companyctx &&
-companyctx acme-bakery.com` experience.
+companyctx fetch acme-bakery.com` experience.
 
 ## The honest coverage matrix
 


### PR DESCRIPTION
## Summary

- Aligns README hero, pipe example, Python subprocess, ARCHITECTURE examples, and ZERO-KEY adoption-wedge prose to use `companyctx fetch <site>` — the actual CLI shape.
- Picks **Option 2** from #14 (align docs to CLI) rather than Option 1 (add a bare-invocation callback). Option 1 is feature scope that belongs in its own discussion; Option 2 is zero code work and matches SKILL.md + Install + Layout, which already use `fetch`.

Closes #14.

## Test plan

- [x] Grep: no remaining bare `companyctx <site>` invocations anywhere in the repo.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)