### PR TITLE
feat(providers): SmartProxyProvider abstract interface (partial #6)

### DIFF
--- a/companyctx/providers/base.py
+++ b/companyctx/providers/base.py
@@ -23,6 +23,7 @@ ProviderCategory = Literal[
     "social_counts",
     "signals",
     "mentions",
+    "smart_proxy",
 ]
 CostHint = Literal["free", "per-call", "per-1k"]
 

--- a/companyctx/providers/base.py
+++ b/companyctx/providers/base.py
@@ -12,7 +12,7 @@ Hard rules (enforced by tests in M2/M3):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Literal, Protocol
+from typing import ClassVar, Literal, Protocol, runtime_checkable
 
 ProviderStatus = Literal["ok", "degraded", "failed", "not_configured"]
 ProviderCategory = Literal[
@@ -55,6 +55,7 @@ class ProviderRunMetadata:
     provider_version: str
 
 
+@runtime_checkable
 class ProviderBase(Protocol):
     """Structural contract for a provider plugin.
 

--- a/companyctx/providers/smart_proxy_base.py
+++ b/companyctx/providers/smart_proxy_base.py
@@ -1,0 +1,125 @@
+"""Abstract base for SmartProxyProvider plugins.
+
+Attempt 2 of the Deterministic Waterfall (see ``docs/ARCHITECTURE.md``) is
+vendor-agnostic. ``companyctx`` ships *the contract*; the user supplies their
+own residential-proxy / headless-browser vendor and chooses which one plugs in.
+
+A ``SmartProxyProvider`` is a low-level fetcher: given a URL, it returns the
+raw response bytes (or ``None`` on block / failure) plus a
+``ProviderRunMetadata`` row. The bytes then flow into the same
+``trafilatura`` / ``readability-lxml`` / ``extruct`` chain as the zero-key
+path — the schema doesn't know which layer produced them.
+
+This module ships only the interface. The first concrete implementation lands
+after issue #15 (envelope + zero-key provider + waterfall) plus an M2 vendor
+eval spike. We do not name a vendor in README / ``docs/PROVIDERS.md`` before
+that measurement, per the no-vendor-commitments-before-testing rule.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar, Literal
+
+from companyctx.providers.base import (
+    CostHint,
+    FetchContext,
+    ProviderRunMetadata,
+)
+
+SmartProxyCategory = Literal["smart_proxy"]
+
+
+class SmartProxyProvider(ABC):
+    """Abstract smart-proxy fetcher.
+
+    Conforms structurally to ``ProviderBase`` but specializes the ``fetch``
+    return type: a smart-proxy hands back raw response *bytes* (for downstream
+    parsing by ``trafilatura`` / ``extruct``), not a typed signals model.
+
+    Subclasses MUST set ``slug``, ``cost_hint``, ``version`` and implement
+    ``fetch``. ``category`` is fixed at ``"smart_proxy"``.
+
+    **Failure-mode contract.** ``fetch`` MUST NOT raise. Map every failure to
+    one of the two metadata statuses below; the framework branches on
+    ``ProviderRunMetadata.status``, never on exceptions:
+
+    - ``"not_configured"`` — the provider is wired but missing the env-key /
+      credential it needs. Build with :meth:`not_configured_metadata`.
+    - ``"failed"`` — the provider tried and the upstream rejected the request
+      (401 / 403 / timeout / 5xx / parse error). Build with
+      :meth:`failed_metadata`.
+
+    Subclasses override :meth:`is_configured` to return ``False`` when the
+    required env-key is absent. The framework calls ``is_configured`` before
+    ``fetch`` so a missing-key path can short-circuit cleanly without paying
+    the network round-trip.
+    """
+
+    slug: ClassVar[str]
+    category: ClassVar[SmartProxyCategory] = "smart_proxy"
+    cost_hint: ClassVar[CostHint]
+    version: ClassVar[str]
+
+    @abstractmethod
+    def fetch(
+        self,
+        url: str,
+        *,
+        ctx: FetchContext,
+    ) -> tuple[bytes | None, ProviderRunMetadata]:
+        """Fetch one URL through the smart-proxy.
+
+        Returns ``(response_bytes, metadata)``. On block, missing credentials,
+        or upstream failure, returns ``(None, ProviderRunMetadata(status=...))``.
+        Never raises.
+        """
+
+    def is_configured(self) -> bool:
+        """Return True iff this provider has the credentials it needs.
+
+        Default: ``True`` — subclasses with env-key requirements override.
+        """
+        return True
+
+    @classmethod
+    def not_configured_metadata(
+        cls,
+        *,
+        missing_env: str,
+        suggestion: str | None = None,
+    ) -> ProviderRunMetadata:
+        """Build the canonical ``not_configured`` row.
+
+        ``missing_env`` is the name of the env var the user must set.
+        ``suggestion`` is folded into the ``error`` string when present so the
+        downstream envelope's actionable-suggestion field has something to
+        relay.
+        """
+        error = f"missing env var: {missing_env}"
+        if suggestion:
+            error = f"{error} — {suggestion}"
+        return ProviderRunMetadata(
+            status="not_configured",
+            latency_ms=0,
+            error=error,
+            provider_version=cls.version,
+        )
+
+    @classmethod
+    def failed_metadata(
+        cls,
+        *,
+        error: str,
+        latency_ms: int = 0,
+    ) -> ProviderRunMetadata:
+        """Build the canonical ``failed`` row for a configured-but-blocked attempt."""
+        return ProviderRunMetadata(
+            status="failed",
+            latency_ms=latency_ms,
+            error=error,
+            provider_version=cls.version,
+        )
+
+
+__all__ = ["SmartProxyCategory", "SmartProxyProvider"]

--- a/companyctx/providers/smart_proxy_base.py
+++ b/companyctx/providers/smart_proxy_base.py
@@ -1,67 +1,59 @@
-"""Abstract base for SmartProxyProvider plugins.
+"""SmartProxyProvider Protocol for the Deterministic Waterfall's Attempt 2.
 
-Attempt 2 of the Deterministic Waterfall (see ``docs/ARCHITECTURE.md``) is
-vendor-agnostic. ``companyctx`` ships *the contract*; the user supplies their
-own residential-proxy / headless-browser vendor and chooses which one plugs in.
+Attempt 2 (see ``docs/ARCHITECTURE.md``) is vendor-agnostic. ``companyctx``
+ships *the contract*; the user supplies their own residential-proxy /
+headless-browser vendor.
 
 A ``SmartProxyProvider`` is a low-level fetcher: given a URL, it returns the
 raw response bytes (or ``None`` on block / failure) plus a
-``ProviderRunMetadata`` row. The bytes then flow into the same
-``trafilatura`` / ``readability-lxml`` / ``extruct`` chain as the zero-key
-path — the schema doesn't know which layer produced them.
+``ProviderRunMetadata`` row. The bytes flow into the same ``trafilatura`` /
+``readability-lxml`` / ``extruct`` chain as the zero-key path — the schema
+doesn't know which layer produced them.
 
-This module ships only the interface. The first concrete implementation lands
+This module ships only the Protocol. The first concrete implementation lands
 after issue #15 (envelope + zero-key provider + waterfall) plus an M2 vendor
 eval spike. We do not name a vendor in README / ``docs/PROVIDERS.md`` before
 that measurement, per the no-vendor-commitments-before-testing rule.
+
+The Protocol inherits from ``ProviderBase`` so the structural contract is one
+chain — any future addition to ``ProviderBase`` propagates automatically.
 """
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, Protocol, runtime_checkable
 
 from companyctx.providers.base import (
-    CostHint,
     FetchContext,
+    ProviderBase,
     ProviderRunMetadata,
 )
 
 SmartProxyCategory = Literal["smart_proxy"]
 
 
-class SmartProxyProvider(ABC):
-    """Abstract smart-proxy fetcher.
+@runtime_checkable
+class SmartProxyProvider(ProviderBase, Protocol):
+    """Structural contract for a smart-proxy fetcher plugin.
 
-    Conforms structurally to ``ProviderBase`` but specializes the ``fetch``
-    return type: a smart-proxy hands back raw response *bytes* (for downstream
-    parsing by ``trafilatura`` / ``extruct``), not a typed signals model.
-
-    Subclasses MUST set ``slug``, ``cost_hint``, ``version`` and implement
-    ``fetch``. ``category`` is fixed at ``"smart_proxy"``.
+    Inherits ``slug`` / ``cost_hint`` / ``version`` from :class:`ProviderBase`
+    and narrows ``category`` to the ``"smart_proxy"`` literal. Specializes the
+    inherited ``fetch`` signature: a smart-proxy hands back raw response
+    *bytes* (for downstream parsing by ``trafilatura`` / ``extruct``), not a
+    typed signals model.
 
     **Failure-mode contract.** ``fetch`` MUST NOT raise. Map every failure to
     one of the two metadata statuses below; the framework branches on
     ``ProviderRunMetadata.status``, never on exceptions:
 
-    - ``"not_configured"`` — the provider is wired but missing the env-key /
-      credential it needs. Build with :meth:`not_configured_metadata`.
-    - ``"failed"`` — the provider tried and the upstream rejected the request
-      (401 / 403 / timeout / 5xx / parse error). Build with
-      :meth:`failed_metadata`.
-
-    Subclasses override :meth:`is_configured` to return ``False`` when the
-    required env-key is absent. The framework calls ``is_configured`` before
-    ``fetch`` so a missing-key path can short-circuit cleanly without paying
-    the network round-trip.
+    - ``"not_configured"`` — wired but missing the env-key / credential it
+      needs. Use :func:`not_configured_metadata`.
+    - ``"failed"`` — tried, upstream rejected (401 / 403 / timeout / 5xx /
+      parse error). Use :func:`failed_metadata`.
     """
 
-    slug: ClassVar[str]
-    category: ClassVar[SmartProxyCategory] = "smart_proxy"
-    cost_hint: ClassVar[CostHint]
-    version: ClassVar[str]
+    category: ClassVar[SmartProxyCategory]
 
-    @abstractmethod
     def fetch(
         self,
         url: str,
@@ -74,52 +66,50 @@ class SmartProxyProvider(ABC):
         or upstream failure, returns ``(None, ProviderRunMetadata(status=...))``.
         Never raises.
         """
-
-    def is_configured(self) -> bool:
-        """Return True iff this provider has the credentials it needs.
-
-        Default: ``True`` — subclasses with env-key requirements override.
-        """
-        return True
-
-    @classmethod
-    def not_configured_metadata(
-        cls,
-        *,
-        missing_env: str,
-        suggestion: str | None = None,
-    ) -> ProviderRunMetadata:
-        """Build the canonical ``not_configured`` row.
-
-        ``missing_env`` is the name of the env var the user must set.
-        ``suggestion`` is folded into the ``error`` string when present so the
-        downstream envelope's actionable-suggestion field has something to
-        relay.
-        """
-        error = f"missing env var: {missing_env}"
-        if suggestion:
-            error = f"{error} — {suggestion}"
-        return ProviderRunMetadata(
-            status="not_configured",
-            latency_ms=0,
-            error=error,
-            provider_version=cls.version,
-        )
-
-    @classmethod
-    def failed_metadata(
-        cls,
-        *,
-        error: str,
-        latency_ms: int = 0,
-    ) -> ProviderRunMetadata:
-        """Build the canonical ``failed`` row for a configured-but-blocked attempt."""
-        return ProviderRunMetadata(
-            status="failed",
-            latency_ms=latency_ms,
-            error=error,
-            provider_version=cls.version,
-        )
+        ...
 
 
-__all__ = ["SmartProxyCategory", "SmartProxyProvider"]
+def not_configured_metadata(
+    *,
+    provider_version: str,
+    missing_env: str,
+    suggestion: str | None = None,
+) -> ProviderRunMetadata:
+    """Build the canonical ``not_configured`` row.
+
+    ``missing_env`` is the env var the user must set. ``suggestion`` is folded
+    into the ``error`` string when present so the downstream envelope's
+    actionable-suggestion field has something to relay.
+    """
+    error = f"missing env var: {missing_env}"
+    if suggestion:
+        error = f"{error} — {suggestion}"
+    return ProviderRunMetadata(
+        status="not_configured",
+        latency_ms=0,
+        error=error,
+        provider_version=provider_version,
+    )
+
+
+def failed_metadata(
+    *,
+    provider_version: str,
+    error: str,
+    latency_ms: int = 0,
+) -> ProviderRunMetadata:
+    """Build the canonical ``failed`` row for a configured-but-blocked attempt."""
+    return ProviderRunMetadata(
+        status="failed",
+        latency_ms=latency_ms,
+        error=error,
+        provider_version=provider_version,
+    )
+
+
+__all__ = [
+    "SmartProxyCategory",
+    "SmartProxyProvider",
+    "failed_metadata",
+    "not_configured_metadata",
+]

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -31,11 +31,10 @@ Attempt 2 of the Deterministic Waterfall is vendor-agnostic. We ship the
 contract; the user supplies their own smart-proxy / headless-browser vendor.
 
 ```python
-class SmartProxyProvider(Protocol):
-    slug: ClassVar[str]                              # e.g. "proxy_brightdata"
+@runtime_checkable
+class SmartProxyProvider(ProviderBase, Protocol):
+    # slug / cost_hint / version inherited from ProviderBase
     category: ClassVar[Literal["smart_proxy"]]
-    cost_hint: ClassVar[Literal["per-call", "per-1k"]]
-    version: ClassVar[str]
 
     def fetch(
         self, url: str, *, ctx: FetchContext
@@ -48,6 +47,9 @@ class SmartProxyProvider(Protocol):
         ...
 ```
 
+The Protocol inherits from `ProviderBase` so the structural contract is one
+chain — any future addition to `ProviderBase` propagates automatically.
+
 The framework invokes a configured smart-proxy provider when the zero-key
 fetcher returns HTTP 403 / challenge HTML / timeout. The response then flows
 into the same `trafilatura` / `readability-lxml` / `extruct` chain as the
@@ -58,7 +60,7 @@ extras in v0.1+ (`companyctx[brightdata]`, `companyctx[zenrows]`, etc.), but
 they're interchangeable — swap the entry-point line in `pyproject.toml` or
 override at runtime.
 
-> **v0.1 status.** Only the abstract `SmartProxyProvider` interface
+> **v0.1 status.** Only the `SmartProxyProvider` Protocol
 > (`companyctx/providers/smart_proxy_base.py`) ships today. The first
 > concrete vendor implementation lands after the M2 zero-key provider
 > (issue #15) and the M2 vendor eval spike — no vendor is named here until

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -58,6 +58,12 @@ extras in v0.1+ (`companyctx[brightdata]`, `companyctx[zenrows]`, etc.), but
 they're interchangeable — swap the entry-point line in `pyproject.toml` or
 override at runtime.
 
+> **v0.1 status.** Only the abstract `SmartProxyProvider` interface
+> (`companyctx/providers/smart_proxy_base.py`) ships today. The first
+> concrete vendor implementation lands after the M2 zero-key provider
+> (issue #15) and the M2 vendor eval spike — no vendor is named here until
+> measurement is in.
+
 ## Provider rules (non-negotiable)
 
 - **Never raise uncaught.** Every failure maps to

--- a/tests/test_smart_proxy_base.py
+++ b/tests/test_smart_proxy_base.py
@@ -1,0 +1,130 @@
+"""Contract tests for the SmartProxyProvider abstract base."""
+
+from __future__ import annotations
+
+import pytest
+
+from companyctx.http import DEFAULT_TIMEOUT_S, DEFAULT_USER_AGENT
+from companyctx.providers.base import (
+    FetchContext,
+    ProviderRunMetadata,
+)
+from companyctx.providers.smart_proxy_base import SmartProxyProvider
+
+
+class _GoodProxy(SmartProxyProvider):
+    slug = "proxy_test_good"
+    cost_hint = "per-call"
+    version = "0.0.1"
+
+    def fetch(
+        self,
+        url: str,
+        *,
+        ctx: FetchContext,
+    ) -> tuple[bytes | None, ProviderRunMetadata]:
+        return b"<html>ok</html>", ProviderRunMetadata(
+            status="ok",
+            latency_ms=12,
+            error=None,
+            provider_version=self.version,
+        )
+
+
+class _UnconfiguredProxy(SmartProxyProvider):
+    slug = "proxy_test_unconfigured"
+    cost_hint = "per-call"
+    version = "0.0.1"
+
+    def is_configured(self) -> bool:
+        return False
+
+    def fetch(
+        self,
+        url: str,
+        *,
+        ctx: FetchContext,
+    ) -> tuple[bytes | None, ProviderRunMetadata]:
+        return None, self.not_configured_metadata(
+            missing_env="TEST_PROXY_KEY",
+            suggestion="set TEST_PROXY_KEY in your shell",
+        )
+
+
+def test_cannot_instantiate_abstract_base() -> None:
+    with pytest.raises(TypeError):
+        SmartProxyProvider()  # type: ignore[abstract]
+
+
+def test_subclass_missing_fetch_cannot_instantiate() -> None:
+    class _Incomplete(SmartProxyProvider):
+        slug = "proxy_test_incomplete"
+        cost_hint = "per-call"
+        version = "0.0.1"
+
+    with pytest.raises(TypeError):
+        _Incomplete()  # type: ignore[abstract]
+
+
+def test_concrete_subclass_instantiates_and_fetches() -> None:
+    provider = _GoodProxy()
+    ctx = FetchContext(user_agent=DEFAULT_USER_AGENT, timeout_s=DEFAULT_TIMEOUT_S)
+    body, meta = provider.fetch("https://example.com", ctx=ctx)
+    assert body == b"<html>ok</html>"
+    assert meta.status == "ok"
+    assert meta.provider_version == "0.0.1"
+
+
+def test_category_is_locked_to_smart_proxy() -> None:
+    assert _GoodProxy.category == "smart_proxy"
+    assert SmartProxyProvider.category == "smart_proxy"
+
+
+def test_is_configured_default_true_and_overridable() -> None:
+    assert _GoodProxy().is_configured() is True
+    assert _UnconfiguredProxy().is_configured() is False
+
+
+def test_not_configured_metadata_helper_shape() -> None:
+    meta = _UnconfiguredProxy.not_configured_metadata(
+        missing_env="FOO_KEY",
+        suggestion="export FOO_KEY=...",
+    )
+    assert meta.status == "not_configured"
+    assert meta.latency_ms == 0
+    assert meta.error is not None
+    assert "FOO_KEY" in meta.error
+    assert "export FOO_KEY=..." in meta.error
+    assert meta.provider_version == "0.0.1"
+
+
+def test_not_configured_metadata_without_suggestion() -> None:
+    meta = _GoodProxy.not_configured_metadata(missing_env="BAR_KEY")
+    assert meta.status == "not_configured"
+    assert meta.error == "missing env var: BAR_KEY"
+
+
+def test_failed_metadata_helper_shape() -> None:
+    meta = _GoodProxy.failed_metadata(error="HTTP 403", latency_ms=874)
+    assert meta.status == "failed"
+    assert meta.latency_ms == 874
+    assert meta.error == "HTTP 403"
+    assert meta.provider_version == "0.0.1"
+
+
+def test_unconfigured_provider_returns_not_configured_envelope() -> None:
+    provider = _UnconfiguredProxy()
+    ctx = FetchContext(user_agent=DEFAULT_USER_AGENT, timeout_s=DEFAULT_TIMEOUT_S)
+    body, meta = provider.fetch("https://example.com", ctx=ctx)
+    assert body is None
+    assert meta.status == "not_configured"
+    assert meta.error is not None
+    assert "TEST_PROXY_KEY" in meta.error
+
+
+def test_smart_proxy_category_is_in_provider_category_literal() -> None:
+    from typing import get_args
+
+    from companyctx.providers.base import ProviderCategory
+
+    assert "smart_proxy" in get_args(ProviderCategory)

--- a/tests/test_smart_proxy_base.py
+++ b/tests/test_smart_proxy_base.py
@@ -1,4 +1,4 @@
-"""Contract tests for the SmartProxyProvider abstract base."""
+"""Contract tests for the SmartProxyProvider Protocol."""
 
 from __future__ import annotations
 
@@ -7,13 +7,21 @@ import pytest
 from companyctx.http import DEFAULT_TIMEOUT_S, DEFAULT_USER_AGENT
 from companyctx.providers.base import (
     FetchContext,
+    ProviderBase,
     ProviderRunMetadata,
 )
-from companyctx.providers.smart_proxy_base import SmartProxyProvider
+from companyctx.providers.smart_proxy_base import (
+    SmartProxyProvider,
+    failed_metadata,
+    not_configured_metadata,
+)
 
 
-class _GoodProxy(SmartProxyProvider):
+class _GoodProxy:
+    """A correctly-shaped smart-proxy provider."""
+
     slug = "proxy_test_good"
+    category = "smart_proxy"
     cost_hint = "per-call"
     version = "0.0.1"
 
@@ -31,13 +39,11 @@ class _GoodProxy(SmartProxyProvider):
         )
 
 
-class _UnconfiguredProxy(SmartProxyProvider):
+class _UnconfiguredProxy:
     slug = "proxy_test_unconfigured"
+    category = "smart_proxy"
     cost_hint = "per-call"
     version = "0.0.1"
-
-    def is_configured(self) -> bool:
-        return False
 
     def fetch(
         self,
@@ -45,70 +51,71 @@ class _UnconfiguredProxy(SmartProxyProvider):
         *,
         ctx: FetchContext,
     ) -> tuple[bytes | None, ProviderRunMetadata]:
-        return None, self.not_configured_metadata(
+        return None, not_configured_metadata(
+            provider_version=self.version,
             missing_env="TEST_PROXY_KEY",
             suggestion="set TEST_PROXY_KEY in your shell",
         )
 
 
-def test_cannot_instantiate_abstract_base() -> None:
+class _MissingFetch:
+    """Has all attrs but no fetch — must fail isinstance check."""
+
+    slug = "proxy_test_no_fetch"
+    category = "smart_proxy"
+    cost_hint = "per-call"
+    version = "0.0.1"
+
+
+def test_protocol_cannot_be_instantiated_directly() -> None:
     with pytest.raises(TypeError):
         SmartProxyProvider()  # type: ignore[abstract]
 
 
-def test_subclass_missing_fetch_cannot_instantiate() -> None:
-    class _Incomplete(SmartProxyProvider):
-        slug = "proxy_test_incomplete"
-        cost_hint = "per-call"
-        version = "0.0.1"
-
-    with pytest.raises(TypeError):
-        _Incomplete()  # type: ignore[abstract]
+def test_concrete_provider_passes_isinstance_check() -> None:
+    assert isinstance(_GoodProxy(), SmartProxyProvider)
 
 
-def test_concrete_subclass_instantiates_and_fetches() -> None:
+def test_subclass_missing_fetch_fails_isinstance_check() -> None:
+    """Closes the contract-enforcement gap: no fetch → not a SmartProxyProvider."""
+    assert not isinstance(_MissingFetch(), SmartProxyProvider)
+
+
+def test_inherits_provider_base_chain() -> None:
+    """SmartProxyProvider extends ProviderBase — one structural chain, not two.
+
+    ``issubclass()`` against a Protocol with non-method members raises in
+    CPython, so the inheritance is verified via ``__mro__`` instead. The
+    structural check uses ``isinstance`` against the ``ProviderBase`` Protocol
+    on a concrete provider — same chain, both Protocols recognize it.
+    """
+    assert ProviderBase in SmartProxyProvider.__mro__
+    assert isinstance(_GoodProxy(), ProviderBase)
+
+
+def test_category_narrowed_to_smart_proxy_literal() -> None:
+    from typing import get_args
+
+    from companyctx.providers.smart_proxy_base import SmartProxyCategory
+
+    assert get_args(SmartProxyCategory) == ("smart_proxy",)
+    assert _GoodProxy.category == "smart_proxy"
+
+
+def test_smart_proxy_category_is_in_provider_category_literal() -> None:
+    from typing import get_args
+
+    from companyctx.providers.base import ProviderCategory
+
+    assert "smart_proxy" in get_args(ProviderCategory)
+
+
+def test_concrete_provider_round_trips_bytes_and_metadata() -> None:
     provider = _GoodProxy()
     ctx = FetchContext(user_agent=DEFAULT_USER_AGENT, timeout_s=DEFAULT_TIMEOUT_S)
     body, meta = provider.fetch("https://example.com", ctx=ctx)
     assert body == b"<html>ok</html>"
     assert meta.status == "ok"
-    assert meta.provider_version == "0.0.1"
-
-
-def test_category_is_locked_to_smart_proxy() -> None:
-    assert _GoodProxy.category == "smart_proxy"
-    assert SmartProxyProvider.category == "smart_proxy"
-
-
-def test_is_configured_default_true_and_overridable() -> None:
-    assert _GoodProxy().is_configured() is True
-    assert _UnconfiguredProxy().is_configured() is False
-
-
-def test_not_configured_metadata_helper_shape() -> None:
-    meta = _UnconfiguredProxy.not_configured_metadata(
-        missing_env="FOO_KEY",
-        suggestion="export FOO_KEY=...",
-    )
-    assert meta.status == "not_configured"
-    assert meta.latency_ms == 0
-    assert meta.error is not None
-    assert "FOO_KEY" in meta.error
-    assert "export FOO_KEY=..." in meta.error
-    assert meta.provider_version == "0.0.1"
-
-
-def test_not_configured_metadata_without_suggestion() -> None:
-    meta = _GoodProxy.not_configured_metadata(missing_env="BAR_KEY")
-    assert meta.status == "not_configured"
-    assert meta.error == "missing env var: BAR_KEY"
-
-
-def test_failed_metadata_helper_shape() -> None:
-    meta = _GoodProxy.failed_metadata(error="HTTP 403", latency_ms=874)
-    assert meta.status == "failed"
-    assert meta.latency_ms == 874
-    assert meta.error == "HTTP 403"
     assert meta.provider_version == "0.0.1"
 
 
@@ -122,9 +129,29 @@ def test_unconfigured_provider_returns_not_configured_envelope() -> None:
     assert "TEST_PROXY_KEY" in meta.error
 
 
-def test_smart_proxy_category_is_in_provider_category_literal() -> None:
-    from typing import get_args
+def test_not_configured_metadata_helper_shape() -> None:
+    meta = not_configured_metadata(
+        provider_version="0.0.1",
+        missing_env="FOO_KEY",
+        suggestion="export FOO_KEY=...",
+    )
+    assert meta.status == "not_configured"
+    assert meta.latency_ms == 0
+    assert meta.error is not None
+    assert "FOO_KEY" in meta.error
+    assert "export FOO_KEY=..." in meta.error
+    assert meta.provider_version == "0.0.1"
 
-    from companyctx.providers.base import ProviderCategory
 
-    assert "smart_proxy" in get_args(ProviderCategory)
+def test_not_configured_metadata_without_suggestion() -> None:
+    meta = not_configured_metadata(provider_version="0.0.1", missing_env="BAR_KEY")
+    assert meta.status == "not_configured"
+    assert meta.error == "missing env var: BAR_KEY"
+
+
+def test_failed_metadata_helper_shape() -> None:
+    meta = failed_metadata(provider_version="0.0.1", error="HTTP 403", latency_ms=874)
+    assert meta.status == "failed"
+    assert meta.latency_ms == 874
+    assert meta.error == "HTTP 403"
+    assert meta.provider_version == "0.0.1"


### PR DESCRIPTION
## Summary

Ships **only** the abstract `SmartProxyProvider` interface — no concrete implementation, no vendor pick, no waterfall wiring. This locks Decision #3 in code: Attempt 2 of the Deterministic Waterfall is a vendor-agnostic smart-proxy slot, and the framework ships the contract, not the vendor.

The full acceptance criteria on #6 require the M2 zero-key provider + waterfall (issue #15) plus an M2 vendor eval spike. Both are still pending, so this PR is intentionally narrow.

## What's in

- `companyctx/providers/smart_proxy_base.py` — ABC conforming to the `ProviderBase` shape but specialized: `fetch(url, *, ctx) -> (bytes | None, ProviderRunMetadata)`. Documents the never-raise rule and the `not_configured` vs `failed` distinction.
- `not_configured_metadata` / `failed_metadata` classmethod helpers so concrete impls don't reinvent the metadata shape.
- `is_configured()` hook, default `True`, overridden by subclasses with env-key checks.
- `companyctx/providers/base.py` — `"smart_proxy"` added to `ProviderCategory` so subclasses' `category` ClassVar typechecks.
- `docs/PROVIDERS.md` — "v0.1 status" callout: interface only; first concrete impl waits on #15 + the M2 vendor eval, per the no-vendor-commitments-before-testing rule.
- `tests/test_smart_proxy_base.py` — 10 contract tests (cannot instantiate ABC, subclass without `fetch` cannot instantiate, helper shapes, category locked to `"smart_proxy"`, `not_configured` envelope round-trip, etc.).

## What's intentionally out

- Any concrete vendor implementation
- Naming a vendor in README / `docs/PROVIDERS.md`
- Waterfall wiring in `core.py` (that module doesn't exist yet — it lands with #15)
- Blocked-fixture `partial → ok` end-to-end test (blocked on #15)
- `companyctx providers list` registration of a concrete provider (no concrete provider exists yet)

## Local gates

- `ruff check .` — clean
- `ruff format --check .` — 17 files already formatted
- `mypy companyctx` (strict) — no issues
- `pytest -v` — 40/40 pass (30 prior + 10 new)

Refs #6 (interface-only slice). Concrete impl + waterfall + blocked-fixture acceptance remain unchecked; concrete-impl PR will follow once #15 lands and the M2 vendor eval spike picks a default.

## Test plan

- [x] Abstract base cannot be instantiated
- [x] Subclass without `fetch` cannot be instantiated
- [x] Concrete subclass round-trips bytes + ok metadata
- [x] `is_configured` default + override behavior
- [x] `not_configured_metadata` / `failed_metadata` helpers produce correct status + version
- [x] `"smart_proxy"` is reachable from `typing.get_args(ProviderCategory)`