### PR TITLE
docs: evidence-grounded RISK-REGISTER + EXTRACTION-STRATEGY (closes #20)

### DIFF
--- a/docs/EXTRACTION-STRATEGY.md
+++ b/docs/EXTRACTION-STRATEGY.md
@@ -46,9 +46,9 @@ gap.
 | **Server-rendered static HTML** — the majority case: WordPress / Squarespace / Wix / Webflow / small-agency custom | `GET /` returns 200, HTML body ≥ 2 KB of meaningful text, no JS required for content | TLS-impersonation fetch → `trafilatura` (primary) / `readability-lxml` (fallback) → `extruct` for JSON-LD / OG / `sameAs` → `BeautifulSoup` footer scan for social anchors | Attempt 1 | **Services-list extraction remains heuristic.** No OSS cleanly produces `services: list[str]` from clean body text (FM-6). **About-page auto-discovery is owned companyctx code** (FM-11), not OSS. Both flag `ProviderRunMetadata.status = "degraded"` on the affected sub-provider so the envelope signals "raw text captured; structured sub-fields empty." |
 | **CDN-anti-bot-fronted** — returns 403 / challenge page on `GET /` | 403 on plain fetch; WAF challenge pages; Cloudflare / DataDome / Akamai / PerimeterX markers in response headers or body | Attempt 1 fails fast; escalate to Attempt 2 (smart-proxy with residential egress) | Attempt 2 | **Without a user-supplied smart-proxy key, this prospect is permanently degraded on homepage-sourced fields** (FM-1). Correct envelope: Attempt 1 → `failed`; Attempt 2 → `not_configured` unless keyed; top-level → `partial` with `suggestion = "configure a smart-proxy provider key"`. |
 | **JS-rendered / SPA surfaces** — Google Business Profile map panel, some franchise-directory inner pages, certain Squarespace-JS variants | `GET /` returns a minimal shell; body < 2 KB meaningful text; visible text on the rendered page is absent from the fetched HTML | Detect low-text-density on the Attempt-1 response → bail early rather than emit half-junk. For *review* fields on JS surfaces with a direct API (Google Places, YouTube Data), prefer Attempt 3. For SPAs without a direct API, emit `degraded` honestly — a headless-browser renderer is **not in the v0.1 scope** per the zero-key ADR | Attempt 3 where a direct API exists; gap otherwise | **Genuine gap for SPA sites without an API.** Transcripts show these are rare in the D100 niches (~5–10% estimate, dominant case is Google Maps panels which *do* have an API); deferring a headless-browser renderer is defensible for v0.1. Revisit if fixtures-corpus measurement shows > 20% of ICP prospects on SPA shapes. |
-| **Review / directory aggregator** — Yelp, Google Business, Houzz, Angi, HomeAdvisor, Birdeye, BBB | Fetch against these domains returns 403 or a thin shell (FM-2, FM-4) | Prefer the **direct API** for Yelp (Yelp Fusion) and Google (Google Places). For the long tail (Birdeye, HomeAdvisor, Angi, BBB), only Attempt 2 helps — none publish a public API. | Attempt 3 for Yelp + Google; Attempt 2 for the long tail | **Long-tail aggregators have no API** — we're permanently at smart-proxy quality there. When Attempt 2 is `not_configured`, envelope emits `status = "partial"` with per-surface `reviews.<platform>.*` fields missing and `suggestion` naming the first aggregator that's configurable. |
-| **Social-platform profile** — Instagram, Facebook, LinkedIn, TikTok, YouTube | Fetching the platform directly either 403s or returns a login-wall shell; follower counts render client-side | **Handle discovery is Attempt 1** (footer anchors + `extruct sameAs`) — companyctx owns that heuristic. **Counts are Attempt 3 for YouTube** (YouTube Data API); **a hard gap for IG / FB / TikTok** without commercial authenticated-graph access (FM-3). | Attempt 1 for handles; Attempt 3 for YouTube counts; gap for IG / FB / TikTok counts | **IG / FB / TikTok follower counts are a permanent `degraded` path.** Document it, don't hide it. Envelope reports: handle confirmed (`ok`), count missing (`degraded` on the per-platform counts provider), top-level `partial`, `suggestion = "IG/FB/TikTok follower counts require authenticated social-graph access"`. |
-| **Brochureware / one-page template / under-construction / parked / Facebook-only** | `GET /` returns 200, HTML parses cleanly, but meaningful text is < 2 KB; no services page; no team page; sometimes a 301 to a parent brand (FM-5); sometimes no domain at all (Facebook-only business) | Attempt 1 handles it; the honest behavior is to **emit a low-confidence envelope** and let synthesis handle it upstream | Attempt 1 | No gap — correct behavior is `ProviderRunMetadata.status = "ok"` per provider, top-level `status = "partial"`, `quality.confidence = "low"`, `fields_missing` populated, `suggestion = "site is brochureware; downstream synthesis should lean on firmographic data"`. Matches the D100 agent pattern that pivots to Apollo firmographics (FM-7). The distinction between "site blocked us" (FM-1) and "site had nothing" (FM-7) is **load-bearing** for downstream decisions; do not collapse them. |
+| **Review / directory aggregator** — Yelp, Google Business, Houzz, Angi, HomeAdvisor, Birdeye, BBB | Fetch against these domains returns 403 or a thin shell (FM-2, FM-4) | Prefer the **direct API** for Yelp (Yelp Fusion) and Google (Google Places). For the long tail (Birdeye, HomeAdvisor, Angi, BBB), only Attempt 2 helps — none publish a public API. | Attempt 3 for Yelp + Google; Attempt 2 for the long tail | **Long-tail aggregators have no API** — we're permanently at smart-proxy quality there. When Attempt 2 is `not_configured`, envelope emits `status = "partial"` with `data.reviews` left `None` (or populated from a surface that did succeed) and `suggestion` naming the first aggregator that's configurable. |
+| **Social-platform profile** — Instagram, Facebook, LinkedIn, TikTok, YouTube | Fetching the platform directly either 403s or returns a login-wall shell; follower counts render client-side | **Handle discovery is Attempt 1** (footer anchors + `extruct sameAs`) — companyctx owns that heuristic. **Counts are Attempt 3 for YouTube** (YouTube Data API); **a hard gap for IG / FB / TikTok** without commercial authenticated-graph access (FM-3). | Attempt 1 for handles; Attempt 3 for YouTube counts; gap for IG / FB / TikTok counts | **IG / FB / TikTok follower counts are a permanent `degraded` path.** Document it, don't hide it. Envelope reports: handle present in `social.handles` (Attempt-1 provider `ok`), count absent from `social.follower_counts` (counts provider `degraded`), top-level `partial`, `suggestion = "IG/FB/TikTok follower counts require authenticated social-graph access"`. |
+| **Brochureware / one-page template / under-construction / parked / Facebook-only** | `GET /` returns 200, HTML parses cleanly, but meaningful text is < 2 KB; no services page; no team page; sometimes a 301 to a parent brand (FM-5); sometimes no domain at all (Facebook-only business) | Attempt 1 handles it; the honest behavior is to **emit the thin data and let synthesis handle it upstream** — optional envelope fields are nullable (SPEC §126) | Attempt 1 | No gap on the fetch itself. Correct envelope is driven entirely by per-provider status: fetchers that succeeded at their extractor job return `ok` (empty outputs are valid); a heuristic provider that expected to find e.g. a services list or `team_size_claim` and couldn't can legitimately return `degraded`, which then maps to top-level `partial` per SPEC §73. The distinction between "site blocked us" (FM-1) and "site had nothing" (FM-7) lives in the per-provider `ProviderRunMetadata.status` values; **do not collapse them**. See RISK-REGISTER FM-7 for the full mapping. |
 
 ## Attempt-by-attempt responsibilities
 
@@ -86,9 +86,13 @@ Known gaps Attempt 1 cannot close deterministically:
   `meet-the-`). When it doesn't find a match, emit `degraded` on the
   about sub-provider, not a silent null.
 - **Effective-vs-requested URL** (FM-5). When a redirect crosses a
-  brand boundary (SLD mismatch), emit `degraded` and preserve both URLs
-  in the envelope. The extractor ran fine; the envelope consumer needs
-  to know the brand identity shifted.
+  brand boundary (SLD mismatch), emit `ProviderRunMetadata.status =
+  "degraded"` and name the mismatch in the `error` string. The v0.1
+  envelope has no field for requested-vs-effective URL; surfacing that
+  pair is a schema evolution (see
+  [RISK-REGISTER §1](RISK-REGISTER.md#1-identity-preservation-on-redirect)).
+  Until that lands, the degraded status + error string is the only
+  signal the envelope can carry.
 
 Heuristic for escalating to Attempt 2: **text density.** If
 `len(extracted_text) < 2000` on a 200 response, or the response status
@@ -142,22 +146,22 @@ counts provider rather than hiding it.
 
 ## Cross-cutting rules
 
-- **Provenance stays on the envelope** (FM-10). Per-field values that
-  can come from multiple surfaces are candidates for a struct carrying
-  `source_url` + `provider_slug`, not bare scalars. v0.1 ships
-  per-provider `ProviderRunMetadata`; field-level provenance extends as
-  data surfaces accumulate. MIT companyctx positions as a deterministic
-  *router*; that claim doesn't hold up without provenance.
-- **Vertical detection is a warning, not a verdict** (FM-8). When the
-  `signals_site_heuristic` provider infers a vertical from the homepage
-  text and an upstream caller passed a different one, emit
-  `quality.warnings = ["upstream vertical tag disagrees with homepage-
-  inferred vertical"]`. The envelope never asserts the "true" vertical
-  — that's a synthesis judgment.
+- **Provenance today is per-provider, not per-field** (FM-10). The
+  v0.1 envelope carries `provenance: dict[slug, ProviderRunMetadata]`
+  (SPEC §61–64); there is no per-field provenance. Field-level
+  provenance is a deferred schema evolution
+  ([RISK-REGISTER §4](RISK-REGISTER.md#4-per-field-provenance));
+  until it lands, each provider is responsible for internal fallback
+  transparency via its `error` string and for not silently mixing
+  primary-domain facts with third-party aggregator facts.
+- **Vertical observation is a deferred schema change** (FM-8). The
+  v0.1 envelope has no field for it; the synthesis layer has to
+  infer. See
+  [RISK-REGISTER §2](RISK-REGISTER.md#2-vertical-observation-and-firmographics-mismatch-warning).
 - **Press / awards is a separate pipeline** (FM-12). The
   site-extraction layer doesn't own it. `mentions_brave_stub` ships as
-  plumbing; coverage requires a keyed search provider. ~50% of D100
-  briefs depend on press-discovery content, so the pipeline can't be
+  plumbing; coverage requires a keyed search provider. Most briefs
+  depend on press-discovery content, so the pipeline can't be
   deferred indefinitely — but it doesn't belong to Attempts 1–3.
 - **No `partial` from half-heuristics.** When a structured sub-field
   can't be extracted cleanly, emit empty + `degraded`, not a noisy

--- a/docs/EXTRACTION-STRATEGY.md
+++ b/docs/EXTRACTION-STRATEGY.md
@@ -1,0 +1,204 @@
+# Extraction Strategy
+
+Which content extractors handle which site shapes, and where deterministic
+extraction is **not** feasible — so the envelope flags `partial` honestly
+instead of pretending the fetch succeeded.
+
+Companion to `docs/RISK-REGISTER.md` (failure modes × envelope surfaces)
+and `docs/ZERO-KEY.md` (zero-key coverage matrix). Read them together.
+
+## Mental model
+
+The Deterministic Waterfall (`docs/ARCHITECTURE.md`) has three attempts.
+Each attempt operates on a *class of site shapes* — not on individual
+domains. The rules below bind site shapes to layers so an implementer can
+answer "which provider should handle this?" without case-by-case
+reasoning.
+
+- **Attempt 1 — Zero-Key Stealth.** TLS-impersonation HTTP fetcher
+  (`curl_cffi`, pinned `chrome146`) + `trafilatura` primary / `readability-lxml`
+  fallback + `extruct` metadata + `BeautifulSoup`-based heuristics. No
+  keys, no cost. Handles the majority case plus the long tail of thin /
+  brochureware sites *honestly* (i.e. emits low-confidence envelopes
+  rather than pretending).
+- **Attempt 2 — Smart-Proxy Provider.** User-keyed residential-proxy /
+  headless-browser provider behind the `SmartProxyProvider` interface.
+  Vendor-agnostic; `companyctx` ships the contract, not a specific
+  vendor. Engages when Attempt 1 hits a CDN anti-bot block or a site
+  requires rendered HTML.
+- **Attempt 3 — Direct-API Provider.** ToS-safe review / social-counts
+  APIs (`reviews_google_places`, `reviews_yelp_fusion`,
+  `social_counts_youtube`). Fills review counts, ratings, and follower
+  counts where no fetch-based approach is deterministic.
+
+Every attempt emits the same envelope shape. The top-level `status`
+aggregates provider-level outcomes.
+
+## Site-shape map
+
+Six shapes appear in the D100 transcripts mined for this doc (evidence
+catalog in `docs/RISK-REGISTER.md`). Each row binds a shape to the
+Waterfall layer that should handle it and names the honest deterministic
+gap.
+
+| Site shape | How to recognize it | Primary approach | Waterfall layer | Honest deterministic gap |
+|---|---|---|---|---|
+| **Server-rendered static HTML** — the majority case: WordPress / Squarespace / Wix / Webflow / small-agency custom | `GET /` returns 200, HTML body ≥ 2 KB of meaningful text, no JS required for content | TLS-impersonation fetch → `trafilatura` (primary) / `readability-lxml` (fallback) → `extruct` for JSON-LD / OG / `sameAs` → `BeautifulSoup` footer scan for social anchors | Attempt 1 | **Services-list extraction remains heuristic.** No OSS cleanly produces `services: list[str]` from clean body text (FM-6). **About-page auto-discovery is owned companyctx code** (FM-11), not OSS. Both flag `ProviderRunMetadata.status = "degraded"` on the affected sub-provider so the envelope signals "raw text captured; structured sub-fields empty." |
+| **CDN-anti-bot-fronted** — returns 403 / challenge page on `GET /` | 403 on plain fetch; WAF challenge pages; Cloudflare / DataDome / Akamai / PerimeterX markers in response headers or body | Attempt 1 fails fast; escalate to Attempt 2 (smart-proxy with residential egress) | Attempt 2 | **Without a user-supplied smart-proxy key, this prospect is permanently degraded on homepage-sourced fields** (FM-1). Correct envelope: Attempt 1 → `failed`; Attempt 2 → `not_configured` unless keyed; top-level → `partial` with `suggestion = "configure a smart-proxy provider key"`. |
+| **JS-rendered / SPA surfaces** — Google Business Profile map panel, some franchise-directory inner pages, certain Squarespace-JS variants | `GET /` returns a minimal shell; body < 2 KB meaningful text; visible text on the rendered page is absent from the fetched HTML | Detect low-text-density on the Attempt-1 response → bail early rather than emit half-junk. For *review* fields on JS surfaces with a direct API (Google Places, YouTube Data), prefer Attempt 3. For SPAs without a direct API, emit `degraded` honestly — a headless-browser renderer is **not in the v0.1 scope** per the zero-key ADR | Attempt 3 where a direct API exists; gap otherwise | **Genuine gap for SPA sites without an API.** Transcripts show these are rare in the D100 niches (~5–10% estimate, dominant case is Google Maps panels which *do* have an API); deferring a headless-browser renderer is defensible for v0.1. Revisit if fixtures-corpus measurement shows > 20% of ICP prospects on SPA shapes. |
+| **Review / directory aggregator** — Yelp, Google Business, Houzz, Angi, HomeAdvisor, Birdeye, BBB | Fetch against these domains returns 403 or a thin shell (FM-2, FM-4) | Prefer the **direct API** for Yelp (Yelp Fusion) and Google (Google Places). For the long tail (Birdeye, HomeAdvisor, Angi, BBB), only Attempt 2 helps — none publish a public API. | Attempt 3 for Yelp + Google; Attempt 2 for the long tail | **Long-tail aggregators have no API** — we're permanently at smart-proxy quality there. When Attempt 2 is `not_configured`, envelope emits `status = "partial"` with per-surface `reviews.<platform>.*` fields missing and `suggestion` naming the first aggregator that's configurable. |
+| **Social-platform profile** — Instagram, Facebook, LinkedIn, TikTok, YouTube | Fetching the platform directly either 403s or returns a login-wall shell; follower counts render client-side | **Handle discovery is Attempt 1** (footer anchors + `extruct sameAs`) — companyctx owns that heuristic. **Counts are Attempt 3 for YouTube** (YouTube Data API); **a hard gap for IG / FB / TikTok** without commercial authenticated-graph access (FM-3). | Attempt 1 for handles; Attempt 3 for YouTube counts; gap for IG / FB / TikTok counts | **IG / FB / TikTok follower counts are a permanent `degraded` path.** Document it, don't hide it. Envelope reports: handle confirmed (`ok`), count missing (`degraded` on the per-platform counts provider), top-level `partial`, `suggestion = "IG/FB/TikTok follower counts require authenticated social-graph access"`. |
+| **Brochureware / one-page template / under-construction / parked / Facebook-only** | `GET /` returns 200, HTML parses cleanly, but meaningful text is < 2 KB; no services page; no team page; sometimes a 301 to a parent brand (FM-5); sometimes no domain at all (Facebook-only business) | Attempt 1 handles it; the honest behavior is to **emit a low-confidence envelope** and let synthesis handle it upstream | Attempt 1 | No gap — correct behavior is `ProviderRunMetadata.status = "ok"` per provider, top-level `status = "partial"`, `quality.confidence = "low"`, `fields_missing` populated, `suggestion = "site is brochureware; downstream synthesis should lean on firmographic data"`. Matches the D100 agent pattern that pivots to Apollo firmographics (FM-7). The distinction between "site blocked us" (FM-1) and "site had nothing" (FM-7) is **load-bearing** for downstream decisions; do not collapse them. |
+
+## Attempt-by-attempt responsibilities
+
+### Attempt 1 — Zero-Key Stealth
+
+**Owns every site shape on first contact.** Its job isn't to succeed
+everywhere; it's to succeed on the majority case (server-rendered
+static HTML) and **fail diagnostically** on the rest so later attempts
+can recover with a meaningful signal.
+
+Day-one providers for Attempt 1:
+
+- `site_text_trafilatura` — primary body-text extractor.
+- `site_text_readability` — bus-factor fallback. Wired day one per
+  `docs/SPEC.md` so single-extractor regressions don't silently cost
+  the envelope.
+- `site_meta_extruct` — JSON-LD / OpenGraph / Twitter cards / `sameAs`
+  social handle discovery.
+- `social_discovery_site` — `BeautifulSoup` footer scan for
+  `a[href*="instagram.com"]` etc., cross-checked against
+  `extruct sameAs`. Owns the FM-14 fix.
+- `signals_site_heuristic` — copyright year, last-blog-post, team-size
+  claim regex, tech-stack fingerprint.
+
+Known gaps Attempt 1 cannot close deterministically:
+
+- **Services-list extraction** (FM-6). The envelope carries
+  `pages.services: list[str]`; when the heuristic doesn't hit, emit an
+  empty list with `ProviderRunMetadata.status = "degraded"` and
+  `suggestion = "services list needs LLM synthesis from raw text"`.
+  Do **not** attempt a half-heuristic that produces a noisy list —
+  downstream synthesis is better served by honest emptiness.
+- **About-page URL auto-discovery** (FM-11). Attempt 1 owns an
+  anchor-text heuristic (`about`, `about-us`, `our-story`, `team`,
+  `meet-the-`). When it doesn't find a match, emit `degraded` on the
+  about sub-provider, not a silent null.
+- **Effective-vs-requested URL** (FM-5). When a redirect crosses a
+  brand boundary (SLD mismatch), emit `degraded` and preserve both URLs
+  in the envelope. The extractor ran fine; the envelope consumer needs
+  to know the brand identity shifted.
+
+Heuristic for escalating to Attempt 2: **text density.** If
+`len(extracted_text) < 2000` on a 200 response, or the response status
+is 403/451/challenge-page-detected, hand off. Do not enter retry loops
+(FM-13 evidence: site-fetch timeouts are essentially absent from the
+corpus; aggressive retry is not the load-bearing investment).
+
+### Attempt 2 — Smart-Proxy Provider
+
+**Owns the CDN-anti-bot shape.** Vendor-agnostic interface; user
+supplies credentials (residential-proxy, headless-browser, or hybrid).
+The specific vendor is not named in public docs until a fixtures-corpus
+spike measures candidates (naming rule in `CLAUDE.md` / workspace
+preferences).
+
+Behavior contract:
+
+- `not_configured` status when no key is set — envelope still emits,
+  top-level `status = "partial"`, `suggestion` names the configuration
+  step.
+- `ok` when it rescues a fetch that Attempt 1 failed; the envelope
+  payload and extractors are identical to Attempt 1's shape.
+- `failed` when configured but blocked (residential IP rotated to a
+  flagged pool, challenge page not cleared). Envelope escalates to
+  Attempt 3 if one applies, or settles on `partial` / `degraded`.
+
+Attempt 2 does **not** attempt JS rendering beyond what the user's
+configured provider exposes. If a prospect needs a headless browser and
+the user's `SmartProxyProvider` doesn't do one, the envelope emits
+`degraded` on JS-dependent fields with `suggestion` naming the gap.
+
+### Attempt 3 — Direct-API Provider
+
+**Owns review counts, ratings, and authenticated-graph follower counts
+where a public API exists.** User-keyed; env-gated; missing-key
+provider statuses are `not_configured`, not `failed`.
+
+Day-one providers for Attempt 3:
+
+- `reviews_google_places` — solves FM-4 and the specific-location
+  subcase of FM-9 (requires the location's GBP place-id, not the brand
+  name).
+- `reviews_yelp_fusion` — solves FM-2. The single strongest
+  transcript-grounded argument for Attempt 3 existing at all.
+- `social_counts_youtube` — YouTube Data API `channels.list` (ToS-safe);
+  the one social-platform with a deterministic follower-count path.
+
+Attempt 3 does **not** try to cover IG / FB / TikTok. The envelope
+documents the gap (FM-3) and emits `degraded` on the per-platform
+counts provider rather than hiding it.
+
+## Cross-cutting rules
+
+- **Provenance stays on the envelope** (FM-10). Per-field values that
+  can come from multiple surfaces are candidates for a struct carrying
+  `source_url` + `provider_slug`, not bare scalars. v0.1 ships
+  per-provider `ProviderRunMetadata`; field-level provenance extends as
+  data surfaces accumulate. MIT companyctx positions as a deterministic
+  *router*; that claim doesn't hold up without provenance.
+- **Vertical detection is a warning, not a verdict** (FM-8). When the
+  `signals_site_heuristic` provider infers a vertical from the homepage
+  text and an upstream caller passed a different one, emit
+  `quality.warnings = ["upstream vertical tag disagrees with homepage-
+  inferred vertical"]`. The envelope never asserts the "true" vertical
+  — that's a synthesis judgment.
+- **Press / awards is a separate pipeline** (FM-12). The
+  site-extraction layer doesn't own it. `mentions_brave_stub` ships as
+  plumbing; coverage requires a keyed search provider. ~50% of D100
+  briefs depend on press-discovery content, so the pipeline can't be
+  deferred indefinitely — but it doesn't belong to Attempts 1–3.
+- **No `partial` from half-heuristics.** When a structured sub-field
+  can't be extracted cleanly, emit empty + `degraded`, not a noisy
+  value. Downstream synthesis is a better consumer of honest absence
+  than of confident garbage.
+- **No vendor names.** Public docs (this one, `PROVIDERS.md`, accepted
+  ADRs) name a vendor for a new layer only after a fixtures-corpus
+  spike measures it. Research files and proposed ADRs can list
+  candidates with a "pending spike" banner. Current accepted vendor
+  picks: `curl_cffi` for TLS impersonation
+  (`decisions/2026-04-20-zero-key-stealth-strategy.md`); `trafilatura`
+  + `readability-lxml` + `extruct` as Attempt-1 extractors
+  (`docs/SPEC.md`); Google Places / Yelp Fusion / YouTube Data API as
+  Attempt-3 providers (`docs/SPEC.md`). Everything else in this doc is
+  a category, not a pick.
+
+## Site-shape frequencies in the D100 corpus
+
+Rough distribution across the 13 heavy transcripts mined — not an SLA
+forecast, a sizing hint for the v0.1 fixtures corpus:
+
+| Shape | Rough share of prospects |
+|---|---|
+| Server-rendered static HTML | ~70% |
+| Review / directory aggregator (for the reviews provider) | universal — every prospect hits ≥ 1 |
+| Social-platform profile (for social handles) | ~90% have ≥ 1 discoverable handle |
+| CDN-anti-bot-fronted | 1–3% — low count, 100% unrecoverable without Attempt 2 |
+| JS-rendered / SPA (excluding Google Maps panels) | ~5–10% |
+| Brochureware / one-page / parked | ~10–15% |
+
+Fixtures-corpus implication: a 5-fixture baseline (sized to
+`expected.json` validation in issue #15) should cover
+server-rendered + aggregator-dependent + social-discoverable +
+CDN-blocked + brochureware. The five cases map one-to-one to the top
+five rows above.
+
+## References
+
+- `docs/SPEC.md` — envelope contract and provider-plugin interface.
+- `docs/ARCHITECTURE.md` — the Deterministic Waterfall diagram.
+- `docs/ZERO-KEY.md` — honest Attempt-1 coverage matrix.
+- `docs/RISK-REGISTER.md` — failure modes × envelope mapping, cited per
+  mode to the D100 transcripts that evidenced each one.
+- `docs/PROVIDERS.md` — day-one provider list with cost hints.

--- a/docs/RISK-REGISTER.md
+++ b/docs/RISK-REGISTER.md
@@ -71,7 +71,7 @@ Envelope enums and semantics (see `docs/SPEC.md` §56–78, §110–118):
 | FM-9 | Franchise / multi-location ambiguity | 2 | Attempt 3 (per-location GBP place-id) | `reviews_google_places` `degraded` → top `partial`; location-vs-aggregate distinction deferred to schema-evolution §3 |
 | FM-10 | Secondary-source cascade without provenance | 5+ | cross-cutting | today's envelope carries per-*provider* provenance only; per-*field* provenance deferred to schema-evolution §4 |
 | FM-11 | About-page URL not auto-discovered | 3+ | Attempt 1 (owned heuristic, not OSS) | `site_about` provider `degraded` → top `partial` |
-| FM-12 | Press / awards discovery needs search, not site fetch | 10+ | separate provider (search-API) | `mentions_*` provider `not_configured` until a search-API key is set → top `partial` (mentions are optional; see §) |
+| FM-12 | Press / awards discovery needs search, not site fetch | 10+ | separate provider (search-API) | `mentions_*` provider `not_configured` until a search-API key is set → top `partial` per SPEC §73 |
 | FM-13 | Site-fetch timeouts / transient failures | 0 observed | Attempt 1 (defensive default only) | provider `failed` — do not over-invest |
 | FM-14 | Homepage fetched but social handles not found | 3+ | Attempt 1 (footer anchor heuristic) | `social_discovery_site` `degraded` → top `partial` |
 
@@ -421,11 +421,23 @@ Envelope enums and semantics (see `docs/SPEC.md` §56–78, §110–118):
   plumbing is `mentions_brave_stub`; real coverage requires a keyed
   search provider.
 - **Envelope mapping.**
-  - `providers.mentions_<slug>: ProviderRunMetadata`.
-  - No key configured: `status = "not_configured"`; top-level can still
-    be `ok` because mentions are non-critical.
-  - `suggestion = "press-release discovery is search-API-backed;
-    configure a search provider key to fill mentions"`.
+  - `provenance["mentions_<slug>"]: ProviderRunMetadata` carries the
+    per-provider status for press discovery.
+  - No key configured: `ProviderRunMetadata.status =
+    "not_configured"`. Per SPEC §73, `not_configured` on any provider
+    forces top-level `status = "partial"` — the envelope tells the
+    caller "this run is missing press coverage because no search key
+    is set." The summary row and this body now agree on that.
+  - `error` names the missing capability
+    (`"press/awards discovery requires a configured search provider"`),
+    `suggestion = "configure a search provider API key to fill
+    mentions"`.
+  - `data.mentions` remains `None` (optional per SPEC §98).
+  - **Design note.** This means a clean zero-key install is
+    `partial`-by-default on every run until a search key is set. That
+    is intentional: silent absence of press coverage is the exact
+    failure the D100 transcripts show — the envelope should signal it
+    loudly, not hide it.
 
 ## FM-13 — Site-fetch timeouts / transient failures
 

--- a/docs/RISK-REGISTER.md
+++ b/docs/RISK-REGISTER.md
@@ -1,0 +1,475 @@
+# Risk Register — D100-grounded failure modes
+
+This document catalogs the Phase 1 web-fetch / content-extraction failure
+modes observed in the D100 cold-outreach pipeline's session transcripts and
+maps each one to the `companyctx` envelope surfaces that must describe it.
+
+It exists so that `expected.json` fixtures, provider implementations, and
+downstream pipelines stop writing against *assumed* failures and start
+writing against *observed* ones.
+
+## Scope
+
+- **Evidence base.** 37 session transcripts committed to
+  `joel-req/new-signal-studio` at `logs/` and `logs/backfill/`, spanning
+  **2026-04-12 → 2026-04-21**. 13 contained substantive Phase 1 activity
+  (web fetch + HTML extraction); 24 were orchestration shells, MCP ping
+  diagnostics, or out-of-scope Apollo / Google Docs / Instantly work.
+  Niches covered: gutter installation, real-estate staging, home
+  inspection, IV-therapy wellness, chiropractic, dermatology-aesthetic,
+  window replacement, waste management. ~180+ per-prospect sub-agent runs
+  sampled.
+- **Only Phase 1 is in scope.** Apollo, Google Docs, Instantly, and
+  launchd/auth failures belong to other systems and are excluded.
+- **Transcripts are evidence, not source code.** They live in
+  `new-signal-studio`; they are not committed here. Quoted snippets are
+  sanitized (business names → `<site>`, owners → `<owner>`, cities and
+  real domains redacted).
+
+## How to read the register
+
+Each failure mode gets:
+
+- **Signature** — what it looks like in a transcript.
+- **Frequency** — how often it fires across the 13 heavy transcripts.
+- **Evidence** — one or two filename:line citations.
+- **Waterfall layer** that should cover it (Attempt 1 zero-key stealth,
+  Attempt 2 smart-proxy provider, Attempt 3 direct-API provider, or
+  a cross-cutting concern).
+- **Envelope mapping** — proposed `ProviderRunMetadata.status`, top-level
+  envelope `status`, `error` template, `suggestion` template.
+- **Agent recovery observed** — what the D100 agent did, and whether it
+  was the right thing for `companyctx` to do.
+
+Envelope enums, for reference (see `docs/SPEC.md`):
+
+- `ProviderRunMetadata.status` ∈ `{ok, degraded, failed, not_configured}`
+- Top-level envelope `status` ∈ `{ok, partial, degraded}`
+
+## Summary
+
+| ID | Mode | Freq (transcripts) | Layer | Envelope shape |
+|---|---|---|---|---|
+| FM-1 | Homepage 403 / hard block by CDN anti-bot | 2 | Attempt 2 | per-provider `failed` → top `partial` if Attempt 2 rescues, else `degraded` |
+| FM-2 | Yelp 403 on server-rendered fetch | 4 | Attempt 3 (Yelp Fusion) | per-provider `failed` → top `partial` |
+| FM-3 | IG / FB follower-count scrape blocked | 4 | gap (no API without commercial key) | per-provider `degraded` → top `partial` |
+| FM-4 | Google review count unreachable (GBP is JS-rendered) | 3 | Attempt 3 (Google Places) | `not_configured` or `failed` → top `partial` |
+| FM-5 | "Under construction" / redirect to parent brand | 1 | Attempt 1 (needs richer envelope metadata) | per-provider `degraded` + `warning` |
+| FM-6 | Services/about content present but unstructured | 13/13 | extraction heuristic (Attempt 1 output) | per-provider `degraded` when sub-fields empty |
+| FM-7 | One-page template / brochureware site | 2+ | Attempt 1 (honest low-confidence) | `ok` per-provider, top `partial` + `quality.confidence = low` |
+| FM-8 | Upstream vertical tag disagrees with homepage-inferred vertical | 1 | Attempt 1 (envelope warning) | top `ok` + `quality.warnings` |
+| FM-9 | Franchise / multi-location ambiguity | 2 | Attempt 3 (per-location GBP place-id) | per-provider `degraded` → top `partial` |
+| FM-10 | Secondary-source cascade without provenance | 5+ | cross-cutting (schema) | per-field `source_url` required |
+| FM-11 | About-page URL not auto-discovered | 3+ | Attempt 1 (owned heuristic, not OSS) | per-provider `degraded` on `site_about` |
+| FM-12 | Press / awards discovery needs search, not site fetch | 10+ | separate provider (search-API) | `mentions_*: not_configured` until keyed |
+| FM-13 | Site-fetch timeouts / transient failures | 0 observed | Attempt 1 (defensive default only) | `failed` — do not over-invest |
+| FM-14 | Homepage fetched but social handles not found | 3+ | Attempt 1 (footer anchor heuristic) | `social.<platform>.handle: degraded` |
+
+## FM-1 — Homepage returns 403 / hard block on root domain
+
+- **Signature.** Sub-agent narrative contains `"<site> blocked WebFetch
+  (403)"` or `"Website blocked 403 — data sourced from BBB, Yelp, search
+  results"`. No retry; no header variation.
+- **Frequency.** 2 transcripts, 2 distinct prospects (window-replacement
+  vendor, roofing/gutter contractor). Low absolute count, 100%
+  unrecoverable in-transcript.
+- **Evidence.**
+  - `backfill-2026-04-18-command-message-d100-command-m-05ed4365.md:3775`
+  - `backfill-2026-04-16-command-message-d100-command-m-167f63bc.md:1605`
+- **Agent recovery.** Pivoted to BBB / Birdeye / search-snippet sources
+  in-LLM with no structured record of the swap. Homepage-sourced fields
+  (services, team, founder bio) absent from the brief.
+- **Waterfall layer.** Attempt 1 can't win — the site is behind a CDN
+  anti-bot layer that rejects the TLS-impersonation fingerprint. Attempt
+  2 (smart-proxy provider with residential egress) is the designed fix.
+  Attempt 3 doesn't help: there is no API for "give me this homepage."
+- **Envelope mapping.**
+  - Attempt 1: `ProviderRunMetadata.status = "failed"`,
+    `error = "CDN anti-bot 403 on homepage"`,
+    `suggestion = "retry via smart-proxy provider with residential egress"`.
+  - If Attempt 2 rescues: top-level `status = "ok"` (or `partial` if
+    other providers degraded).
+  - If Attempt 2 is `not_configured` or also fails: top-level
+    `status = "partial"` with `fields_missing` populated and
+    `suggestion = "configure a smart-proxy provider key"`.
+
+## FM-2 — Yelp returns 403 on server-rendered fetch
+
+- **Signature.** `"Yelp 403 blocked"`; `"Yelp blocked, Google not
+  confirmable"`. Single most common Phase 1 data-loss pattern in the
+  corpus.
+- **Frequency.** 4 transcripts, 5+ distinct prospects.
+- **Evidence.**
+  - `backfill-2026-04-17-command-message-d100-command-m-77656e04.md:2840`
+  - `backfill-2026-04-17-command-message-d100-command-m-1ff83f41.md:3126`
+- **Agent recovery.** Substituted Birdeye / HomeAdvisor / Angi / BBB /
+  Houzz aggregates where available; otherwise `INSUFFICIENT DATA`.
+- **Waterfall layer.** Attempt 1 fails reliably. Attempt 2 (smart-proxy)
+  may or may not beat Yelp's detection. **Attempt 3 is the designed
+  fix** — the Yelp Fusion API exists for exactly this. This is the
+  single strongest transcript-grounded argument for Attempt 3 existing.
+- **Envelope mapping.**
+  - Scraped-Yelp provider: `ProviderRunMetadata.status = "failed"`.
+  - `reviews_yelp_fusion` if no key: `status = "not_configured"`.
+  - Top-level `status = "partial"`,
+    `fields_missing = ["reviews.yelp.count", "reviews.yelp.rating"]`,
+    `suggestion = "configure Yelp Fusion direct-API key to bypass
+    scraping"`.
+
+## FM-3 — Instagram / Facebook follower-count scrape blocked
+
+- **Signature.** `"IG profile scrapes were blocked"`, `"Facebook
+  follower counts could not be extracted from public previews"`.
+- **Frequency.** 4 transcripts, 5+ distinct prospects. Failure is
+  asymmetric: FB likes succeed ~70% of the time, IG follower count
+  succeeds <30%.
+- **Evidence.**
+  - `d100-run-waste-management-services-2026-04-21-e1155059-3079-4046-b663-18f8258a314f.md:2115`
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:4107`
+- **Agent recovery.** Marked the count `INSUFFICIENT DATA`. Often
+  captured the platform's *presence* (handle is active) but not the
+  *numeric count*.
+- **Waterfall layer.** Attempt 1 confirms the handle via site-linked-out
+  detection. Attempt 2 proxy helps only marginally. Attempt 3 is a
+  genuine **Waterfall gap**: IG / FB / TikTok follower counts have no
+  deterministic public API without a commercial authenticated-graph
+  agreement.
+- **Envelope mapping.**
+  - Per-handle `ProviderRunMetadata.status = "degraded"` — handle
+    confirmed, count missing. This is the cleanest transcript-backed
+    argument for keeping the three-state provider enum instead of
+    collapsing to binary ok/fail.
+  - `error = "social-platform login-wall on counts"`,
+    `suggestion = "handle confirmed; follower count requires
+    authenticated social-graph API"`.
+  - YouTube is the exception: `social_counts_youtube` (YouTube Data API)
+    covers it cleanly under Attempt 3 when keyed.
+
+## FM-4 — Google review count simply never surfaces
+
+- **Signature.** `"Google rating and review count not surfaced"`;
+  `"Google-specific not surfaced"`. Distinct from FM-2: no explicit 403;
+  the number isn't visible via fetch + search-snippet approaches.
+- **Frequency.** 3+ transcripts, high per-transcript occurrence count.
+  The home-inspection vertical alone showed 6+ prospects with this flag.
+- **Evidence.**
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:3989`
+  - `backfill-2026-04-17-command-message-d100-command-m-57f83f37.md:1820`
+- **Agent recovery.** Captured whatever aggregates were visible
+  (Birdeye, HomeAdvisor, Houzz, Angi, franchise-rollup pages) and
+  flagged Google-specific numbers as `INSUFFICIENT DATA`.
+- **Why it happens.** The Google Business Profile map panel is
+  JS-rendered inside a SPA surface. This is not a captcha; it is
+  structural. A stealth HTTP fetch will never parse it.
+- **Waterfall layer.** Attempts 1 and 2 cannot solve this. **Attempt 3
+  (`reviews_google_places`, Google Places API) is the only deterministic
+  path.** Second-strongest transcript argument for Attempt 3.
+- **Envelope mapping.**
+  - `reviews_google_places` with no key: `status = "not_configured"`,
+    `suggestion = "enable Google Places API via GOOGLE_PLACES_API_KEY"`.
+  - With key but API rejects: `status = "failed"`.
+  - Top-level `status = "partial"` with
+    `fields_missing = ["reviews.google.count", "reviews.google.rating"]`.
+
+## FM-5 — "Under construction" or redirect to parent brand
+
+- **Signature.** `"<site> is explicitly 'under construction'"`;
+  `"<site> redirects to <parent-brand-site>"`.
+- **Frequency.** 1 transcript, 1 direct occurrence + 1 adjacent note.
+  Low count but a clean, named shape.
+- **Evidence.**
+  - `backfill-2026-04-18-command-message-d100-command-m-05ed4365.md:3776`
+- **Agent recovery.** Followed the redirect manually, pulled data from
+  the parent-brand site, preserved the original business name in the
+  brief. Caveat: the redirect target is a *different* business entity
+  (franchise parent), so some imported facts don't describe the
+  prospect's specific location.
+- **Waterfall layer.** Attempt 1 — the need is richer envelope
+  metadata, not a new layer.
+- **Envelope mapping.**
+  - Preserve both `requested_url` and `effective_url` in the envelope
+    (or on `pages`).
+  - Attempt-1 `ProviderRunMetadata.status = "degraded"` when
+    `effective_url` differs from `requested_url` across a brand boundary
+    (heuristic: SLD mismatch).
+  - `suggestion = "site redirected to parent domain; extracted data may
+    describe the parent brand, not this prospect"`.
+
+## FM-6 — Services / about content present but unstructured
+
+- **Signature.** Briefs inline services, credentials, team names, and
+  founding-year into prose — there is no structured `services[]` or
+  `credentials[]` payload passed between sub-agents. Every downstream
+  consumer re-reads HTML to get at 2 KB of facts.
+- **Frequency.** Effectively **every** high-activity transcript
+  (13/13). This is the **dominant token-cost failure** across the
+  corpus, not a fetch failure.
+- **Evidence.**
+  - `d100-run-waste-management-services-2026-04-21-e1155059-3079-4046-b663-18f8258a314f.md:2085`
+  - `backfill-2026-04-18-command-message-d100-command-m-9aea3234.md:827`
+- **Why it matters.** This *is* the companyctx wedge: emit structured
+  fields, so synthesis never re-fetches. Confirms the OSS-extraction
+  gap that services-list extraction has no clean OSS (see
+  `docs/EXTRACTION-STRATEGY.md`).
+- **Waterfall layer.** Extraction-layer concern; orthogonal to the
+  Waterfall. Applies to Attempt-1 output shape.
+- **Envelope mapping.**
+  - `signals_site_heuristic` and related providers emit
+    `status = "ok"` when structured fields (`services`, `team`,
+    `credentials`, `founded_year`) populate.
+  - `status = "degraded"` when raw `pages.homepage_text` was captured
+    but structured sub-fields are empty because heuristics didn't hit.
+  - `suggestion = "services list needs LLM synthesis from raw text"`
+    when structured extraction fails but raw text is present.
+
+## FM-7 — One-page / brochureware / relationship-driven B2B site
+
+- **Signature.** Brief flags `"extremely low digital footprint"` or
+  `"no dedicated social surfaced"`, or runs short on differentiators
+  despite a successful fetch.
+- **Frequency.** 2 transcripts, 3+ prospects.
+- **Evidence.**
+  - `backfill-2026-04-16-command-message-d100-command-m-167f63bc.md:1473`
+  - `backfill-2026-04-18-command-message-d100-command-m-05ed4365.md:3669`
+- **Agent recovery.** Accepted thin data, pivoted script angles to lean
+  on Apollo firmographics. This is the right pattern to mirror.
+- **Waterfall layer.** Attempt 1 succeeds fetch-wise; no later layer
+  helps. The fetch worked; the site just has nothing to extract.
+- **Envelope mapping.**
+  - Attempt-1 `ProviderRunMetadata.status = "ok"`.
+  - Top-level `status = "partial"` with `quality.confidence = "low"`
+    and `fields_missing` populated.
+  - `suggestion = "site is brochureware; downstream synthesis should
+    lean on firmographic data"`.
+  - **Do not map to `degraded` or `failed`** — the fetch succeeded. The
+    distinction between "site blocked us" and "site had nothing" is
+    load-bearing for downstream decisions.
+
+## FM-8 — Upstream vertical tag disagrees with homepage-inferred vertical
+
+- **Signature.** `"Apollo's 'real estate' classification confirmed
+  wrong — they're portable sanitation + site services."`
+- **Frequency.** 1 transcript (waste-management 2026-04-21), 2
+  prospects in a single batch.
+- **Evidence.**
+  - `d100-run-waste-management-services-2026-04-21-e1155059-3079-4046-b663-18f8258a314f.md:2059`
+  - `d100-run-waste-management-services-2026-04-21-e1155059-3079-4046-b663-18f8258a314f.md:2139`
+- **Agent recovery.** Corrected the classification from homepage text
+  mid-research. The correction lives in prose, not in a structured
+  field.
+- **Waterfall layer.** Attempt 1 resolves.
+- **Envelope mapping.** This is the canonical "companyctx is a router"
+  signal. Emit a heuristic `vertical_detected` field on
+  `signals_site_heuristic` output and surface a mismatch when upstream
+  firmographics disagree:
+  - Top-level `status = "ok"` with
+    `quality.warnings = ["upstream vertical tag disagrees with
+    homepage-inferred vertical"]`.
+  - The envelope never asserts the "true" vertical — that's a synthesis
+    judgment. It reports the observation.
+
+## FM-9 — Franchise / multi-location ambiguity
+
+- **Signature.** `"franchise aggregate 4.9/747"`; `"franchise page
+  reports 37 reviews / 5.0; Google-specific not surfaced"`.
+- **Frequency.** 2 transcripts (home-inspection, real-estate-staging),
+  6+ prospects.
+- **Evidence.**
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:4141`
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:4146`
+- **Agent recovery.** Kept both numbers, prefixed one "franchise
+  aggregate." No structure.
+- **Waterfall layer.** Attempt 3 (Google Places) is the real fix, same
+  family as FM-4 but with a subtlety: callers must pass the *location-
+  specific* GBP place-id, not just the brand name.
+- **Envelope mapping.**
+  - `reviews.google` carries `scope: "location" | "parent_brand" |
+    "aggregate"` (or equivalent) so downstream callers can distinguish.
+  - When only aggregate is available: `ProviderRunMetadata.status =
+    "degraded"`, top-level `partial`.
+  - `suggestion = "parent-brand aggregate captured; location-level
+    numbers require Google Places API on the specific GBP listing"`.
+
+## FM-10 — Secondary-source cascade without provenance
+
+- **Signature.** When primary sources (FM-1, FM-2, FM-4) block, the
+  agent silently pulls from BBB, Birdeye, HomeAdvisor, Houzz,
+  RocketReach, press-release wires, chamber sites. No structured record
+  of which fact came from where.
+- **Frequency.** Co-occurs with every FM-1/FM-2/FM-4 firing: 5+
+  transcripts, 10+ prospects.
+- **Evidence.**
+  - `backfill-2026-04-16-command-message-d100-command-m-167f63bc.md:1605`
+  - `backfill-2026-04-18-command-message-d100-command-m-05ed4365.md:3775`
+- **Waterfall layer.** Cross-cutting — this is a schema concern, not a
+  single-attempt concern.
+- **Envelope mapping.** Schema guidance:
+  - Each extracted value that can come from multiple surfaces should be
+    a struct carrying `source_url` + originating `provider_slug`, not a
+    bare scalar. The v0.1 envelope already models per-provider
+    provenance via `ProviderRunMetadata`; reviews / mentions / signals
+    that can spill across surfaces should extend this down to the
+    field level over time.
+  - When a field's value was sourced from a fallback surface rather
+    than the prospect's own domain, top-level `status = "partial"` and
+    `suggestion` should name the swap.
+- **Rationale.** companyctx is MIT and permanent-public. "Deterministic
+  router" loses meaning if provenance is implicit.
+
+## FM-11 — About-page URL not auto-discovered
+
+- **Signature.** Brief references founder name from LinkedIn / Apollo
+  but not from the site's about page; founder story is cited from a
+  local magazine interview, not the vendor's own About surface.
+- **Frequency.** 3+ transcripts, recurring pattern.
+- **Evidence.**
+  - `d100-run-waste-management-services-2026-04-21-e1155059-3079-4046-b663-18f8258a314f.md:2055`
+- **Why it happens.** OSS extractors clean body text but do not
+  *discover* which URL on a site is the About page. Small businesses
+  hide it under "Our Story", "Meet the Team", or a nav dropdown.
+- **Waterfall layer.** Attempt 1 — requires owned anchor-text heuristic
+  code (not OSS).
+- **Envelope mapping.**
+  - When the `/` fetch succeeds but the about-page URL isn't found:
+    per-provider `status = "degraded"` on a `site_about` sub-provider.
+  - `suggestion = "about-page URL not auto-detected — pass
+    --about-url=<path> or enable the footer anchor-text scan"`.
+
+## FM-12 — Press / awards discovery needs search, not site fetch
+
+- **Signature.** Briefs cite awards ("2024 NWRA national award"), press
+  ("Forbes Homes #1 Best Gutter Guard 2023"), and credentials ("GentleCure
+  SRT", "Inc. 5000 alum") — almost none of these come from the prospect's
+  own site.
+- **Frequency.** Most high-activity transcripts (10+). Roughly 50% of
+  briefs depend on press-discovery content.
+- **Evidence.**
+  - `backfill-2026-04-17-command-message-d100-command-m-57f83f37.md:2296`
+  - `backfill-2026-04-18-command-message-d100-command-m-9aea3234.md:854`
+- **Waterfall layer.** Distinct from the three site-fetch attempts;
+  press discovery is its own pipeline (search-API backed). The day-one
+  plumbing is `mentions_brave_stub`; real coverage requires a keyed
+  search provider.
+- **Envelope mapping.**
+  - `providers.mentions_<slug>: ProviderRunMetadata`.
+  - No key configured: `status = "not_configured"`; top-level can still
+    be `ok` because mentions are non-critical.
+  - `suggestion = "press-release discovery is search-API-backed;
+    configure a search provider key to fill mentions"`.
+
+## FM-13 — Site-fetch timeouts / transient failures
+
+- **Signature.** Would look like `"request timed out"`, `"connection
+  reset"`, `"retry-after"` in transcripts.
+- **Frequency.** **0 occurrences** on site fetches across the corpus.
+  The only "timeout" hits were Apollo MCP rate-limit errors (out of
+  scope) and the agent's own `sleep` helper.
+- **Waterfall layer.** Attempt 1 — defensive default.
+- **Envelope mapping.** Still support it
+  (`ProviderRunMetadata.status = "failed"`,
+  `error = "fetch timeout after Ns"`,
+  `suggestion = "retry with longer timeout or escalate to smart-proxy"`)
+  — but do **not** over-invest. Dominant Phase 1 failure mode is
+  *blocks*, not *flakes*. Transcript evidence says aggressive retry /
+  backoff is at best a tertiary concern. Attempt-2 escalation is the
+  higher-leverage place to spend engineering.
+
+## FM-14 — Homepage fetched but social handles not found
+
+- **Signature.** `"Instagram and Facebook URLs / follower counts not
+  surfaced"`; `"no IG surfaced in searches"`.
+- **Frequency.** 3+ transcripts, 5+ prospects.
+- **Evidence.**
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:4020`
+  - `backfill-2026-04-17-command-message-d100-command-m-9bc12c4e.md:4071`
+- **Why it happens.** This is the canonical deterministic companyctx
+  job: walk the homepage DOM for `a[href*="instagram.com"]`, etc., and
+  cross-check against `extruct` `sameAs` metadata. Transcripts show
+  agents giving up rather than doing this pass.
+- **Waterfall layer.** Attempt 1 (`social_discovery_site`) — owned
+  extraction heuristic.
+- **Envelope mapping.**
+  - When homepage fetch succeeds but no handle link is found:
+    `social.<platform>.handle` absent; provider
+    `ProviderRunMetadata.status = "degraded"`.
+  - `suggestion = "no homepage-footer link; downstream may try
+    business-name search on the platform"`.
+- **Refinement note.** Distinct from FM-3 (handle known, count blocked)
+  and from "handle misattribution" (wrong handle). These are three
+  separate failure shapes; keeping them distinct matters for
+  `expected.json` design.
+
+## Taxonomy diff vs. prior research
+
+`companyctx`'s design has been informed by two prior research files in
+`noontide-projects` (local-only; not committed here). This section
+captures how the transcript evidence compares.
+
+### Confirmed
+
+- **Primary-domain blocks** and **review-surface captchas / blocks**
+  (carveout §7) confirmed — FM-1, FM-2, FM-4.
+- **Low-info one-page sites** (carveout §7) confirmed — FM-7.
+- **Services-list extraction is an OSS gap** (extraction-OSS §Gaps)
+  confirmed — FM-6, universal across the corpus.
+- **About-page auto-discovery is an OSS gap** (extraction-OSS §Gaps)
+  confirmed — FM-11.
+- **Press-release discovery is out of content-extraction scope**
+  (extraction-OSS §Gaps) confirmed — FM-12 fires on ~50% of briefs.
+
+### Refined
+
+- **Google-captcha vs. Google-SPA (FM-4).** Prior taxonomy bundled
+  these. Evidence shows the dominant Google failure is structural (GBP
+  is JS-rendered + requires an API), not captcha. Envelope must
+  distinguish `captcha_challenge` from `requires_direct_api` — they
+  suggest different recoveries.
+- **Social handle modes (FM-3, FM-14).** Prior taxonomy framed this as
+  "handle misattribution." Transcripts show two separate modes:
+  (a) handle not discovered at all (FM-14); (b) handle known but count
+  blocked (FM-3). These are different envelope states.
+- **Franchise / parent-brand ambiguity (FM-9).** Not previously
+  enumerated. A distinct subcategory requiring per-location GBP
+  place-id resolution.
+
+### Contradicted / new
+
+- **Site-fetch timeouts (FM-13) are essentially absent.** Prior
+  instinct was to build retry/backoff first. Corpus evidence argues
+  against it. Invest in Attempt-2 escalation, not Attempt-1 retry
+  loops.
+- **Upstream-vertical-misclassification (FM-8) is net new.** Suggests
+  the envelope should emit a `vertical_detected` observation;
+  firmographics lie often enough to matter.
+- **Provenance-per-field (FM-10) is net new.** Transcripts silently mix
+  homepage, BBB, Birdeye, press-wire, and search-snippet sources. MIT
+  companyctx must carry per-field provenance for the "deterministic
+  router" claim to hold up in review.
+- **Under-construction / redirect shape (FM-5) is net new.** Low
+  frequency, clean case — captured so fixtures cover it.
+
+## Consumer notes
+
+- **For `docs/EXTRACTION-STRATEGY.md`.** This register maps *failures*;
+  the strategy doc maps *site shapes* to extraction approaches, then
+  calls out the honest deterministic gaps. Read them together.
+- **For `expected.json` authors.** Each fixture should encode which
+  failure mode applies (if any) so the expected envelope's `status`,
+  `error`, and `suggestion` fields are grounded, not guessed. A
+  fixture for a Yelp-blocked prospect should ship the partial envelope
+  this register specifies for FM-2, verbatim.
+- **For provider implementations.** `ProviderRunMetadata.status`
+  transitions are load-bearing. The enum is four-valued on purpose;
+  FM-3 and FM-14 argue against collapsing `degraded` into `failed`.
+
+## What this register does not do
+
+- It does not quantify failure probability outside the observed
+  niches. Eight niches is enough to ground the *shapes* of failure;
+  it is not enough to forecast v0.2 SLAs.
+- It does not prescribe retry policy, timeout values, or per-host
+  rate-limit budgets. Those belong to provider implementations.
+- It does not name vendors for Attempt 2 (smart-proxy) or specific
+  OSS picks for new heuristics. Those decisions await measurement on
+  the fixtures corpus (see `docs/PROVIDERS.md` and the zero-key
+  strategy ADR for the naming rule).

--- a/docs/RISK-REGISTER.md
+++ b/docs/RISK-REGISTER.md
@@ -41,29 +41,39 @@ Each failure mode gets:
 - **Agent recovery observed** — what the D100 agent did, and whether it
   was the right thing for `companyctx` to do.
 
-Envelope enums, for reference (see `docs/SPEC.md`):
+Envelope enums and semantics (see `docs/SPEC.md` §56–78, §110–118):
 
-- `ProviderRunMetadata.status` ∈ `{ok, degraded, failed, not_configured}`
-- Top-level envelope `status` ∈ `{ok, partial, degraded}`
+- `ProviderRunMetadata.status` ∈ `{ok, degraded, failed, not_configured}`.
+- Top-level envelope `status` ∈ `{ok, partial, degraded}`.
+- `ok` — every required provider succeeded.
+- `partial` — **at least one provider** returned `degraded`, `failed`,
+  or `not_configured`, but `data` is still schema-conformant.
+- `degraded` — **no provider succeeded**.
+- Only fields declared in `docs/SPEC.md` §82–108 are envelope-available
+  today. This register sticks to those. Cases where the honest mapping
+  needs a field that doesn't exist yet are deferred to the
+  [Schema-evolution proposals](#schema-evolution-proposals-non-normative)
+  appendix and are **not** consumable by `#15` without that schema
+  work landing first.
 
 ## Summary
 
-| ID | Mode | Freq (transcripts) | Layer | Envelope shape |
+| ID | Mode | Freq (transcripts) | Layer | Envelope shape (today's schema) |
 |---|---|---|---|---|
-| FM-1 | Homepage 403 / hard block by CDN anti-bot | 2 | Attempt 2 | per-provider `failed` → top `partial` if Attempt 2 rescues, else `degraded` |
-| FM-2 | Yelp 403 on server-rendered fetch | 4 | Attempt 3 (Yelp Fusion) | per-provider `failed` → top `partial` |
-| FM-3 | IG / FB follower-count scrape blocked | 4 | gap (no API without commercial key) | per-provider `degraded` → top `partial` |
-| FM-4 | Google review count unreachable (GBP is JS-rendered) | 3 | Attempt 3 (Google Places) | `not_configured` or `failed` → top `partial` |
-| FM-5 | "Under construction" / redirect to parent brand | 1 | Attempt 1 (needs richer envelope metadata) | per-provider `degraded` + `warning` |
-| FM-6 | Services/about content present but unstructured | 13/13 | extraction heuristic (Attempt 1 output) | per-provider `degraded` when sub-fields empty |
-| FM-7 | One-page template / brochureware site | 2+ | Attempt 1 (honest low-confidence) | `ok` per-provider, top `partial` + `quality.confidence = low` |
-| FM-8 | Upstream vertical tag disagrees with homepage-inferred vertical | 1 | Attempt 1 (envelope warning) | top `ok` + `quality.warnings` |
-| FM-9 | Franchise / multi-location ambiguity | 2 | Attempt 3 (per-location GBP place-id) | per-provider `degraded` → top `partial` |
-| FM-10 | Secondary-source cascade without provenance | 5+ | cross-cutting (schema) | per-field `source_url` required |
-| FM-11 | About-page URL not auto-discovered | 3+ | Attempt 1 (owned heuristic, not OSS) | per-provider `degraded` on `site_about` |
-| FM-12 | Press / awards discovery needs search, not site fetch | 10+ | separate provider (search-API) | `mentions_*: not_configured` until keyed |
-| FM-13 | Site-fetch timeouts / transient failures | 0 observed | Attempt 1 (defensive default only) | `failed` — do not over-invest |
-| FM-14 | Homepage fetched but social handles not found | 3+ | Attempt 1 (footer anchor heuristic) | `social.<platform>.handle: degraded` |
+| FM-1 | Homepage 403 / hard block by CDN anti-bot | 2 | Attempt 2 | Attempt-1 provider `failed`; top-level `partial` if any other provider succeeded, else `degraded` |
+| FM-2 | Yelp 403 on server-rendered fetch | 4 | Attempt 3 (Yelp Fusion) | scraped-Yelp provider `failed` or Fusion `not_configured` → top `partial` |
+| FM-3 | IG / FB follower-count scrape blocked | 4 | gap (no API without commercial key) | counts provider `degraded` → top `partial` |
+| FM-4 | Google review count unreachable (GBP is JS-rendered) | 3 | Attempt 3 (Google Places) | `reviews_google_places` `not_configured` or `failed` → top `partial` |
+| FM-5 | "Under construction" / redirect to parent brand | 1 | Attempt 1 | Attempt-1 provider `degraded`, top `partial`; identity distinction deferred (see schema-evolution §1) |
+| FM-6 | Services/about content present but unstructured | 13/13 | extraction heuristic (Attempt 1) | `signals_site_heuristic` / services extractor `degraded` when `pages.services == []` → top `partial` |
+| FM-7 | One-page template / brochureware site | 2+ | Attempt 1 (honest thin data) | per-provider `ok` on successful fetches; top `ok` (nulls on empty optional fields) or `partial` if a heuristic provider reports `degraded` |
+| FM-8 | Upstream vertical tag disagrees with homepage-inferred vertical | 1 | Attempt 1 | today's envelope has no field for this; see schema-evolution §2 |
+| FM-9 | Franchise / multi-location ambiguity | 2 | Attempt 3 (per-location GBP place-id) | `reviews_google_places` `degraded` → top `partial`; location-vs-aggregate distinction deferred to schema-evolution §3 |
+| FM-10 | Secondary-source cascade without provenance | 5+ | cross-cutting | today's envelope carries per-*provider* provenance only; per-*field* provenance deferred to schema-evolution §4 |
+| FM-11 | About-page URL not auto-discovered | 3+ | Attempt 1 (owned heuristic, not OSS) | `site_about` provider `degraded` → top `partial` |
+| FM-12 | Press / awards discovery needs search, not site fetch | 10+ | separate provider (search-API) | `mentions_*` provider `not_configured` until a search-API key is set → top `partial` (mentions are optional; see §) |
+| FM-13 | Site-fetch timeouts / transient failures | 0 observed | Attempt 1 (defensive default only) | provider `failed` — do not over-invest |
+| FM-14 | Homepage fetched but social handles not found | 3+ | Attempt 1 (footer anchor heuristic) | `social_discovery_site` `degraded` → top `partial` |
 
 ## FM-1 — Homepage returns 403 / hard block on root domain
 
@@ -84,14 +94,21 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   2 (smart-proxy provider with residential egress) is the designed fix.
   Attempt 3 doesn't help: there is no API for "give me this homepage."
 - **Envelope mapping.**
-  - Attempt 1: `ProviderRunMetadata.status = "failed"`,
+  - Attempt-1 provider (e.g. `site_text_trafilatura`):
+    `ProviderRunMetadata.status = "failed"`,
     `error = "CDN anti-bot 403 on homepage"`,
-    `suggestion = "retry via smart-proxy provider with residential egress"`.
-  - If Attempt 2 rescues: top-level `status = "ok"` (or `partial` if
-    other providers degraded).
-  - If Attempt 2 is `not_configured` or also fails: top-level
-    `status = "partial"` with `fields_missing` populated and
-    `suggestion = "configure a smart-proxy provider key"`.
+    `suggestion = "retry via smart-proxy provider with residential
+    egress"`.
+  - If Attempt 2 rescues the homepage and no other provider degrades:
+    top-level `status = "ok"`.
+  - If Attempt 2 is `not_configured` and some other providers succeed
+    (e.g. review / social providers on non-homepage surfaces): top-level
+    `status = "partial"`; homepage-sourced `CompanyContext` fields
+    (`pages.homepage_text`, `pages.about_text`, heuristic sub-fields)
+    remain `None`; `error` and `suggestion` come from the primary
+    degraded provider, typically `"configure a smart-proxy provider
+    key"`.
+  - If no provider succeeded: top-level `status = "degraded"`.
 
 ## FM-2 — Yelp returns 403 on server-rendered fetch
 
@@ -112,9 +129,13 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   - Scraped-Yelp provider: `ProviderRunMetadata.status = "failed"`.
   - `reviews_yelp_fusion` if no key: `status = "not_configured"`.
   - Top-level `status = "partial"`,
-    `fields_missing = ["reviews.yelp.count", "reviews.yelp.rating"]`,
+    `error = "yelp scrape blocked and yelp_fusion not configured"`,
     `suggestion = "configure Yelp Fusion direct-API key to bypass
     scraping"`.
+  - `data.reviews` remains `None` (or populated from another review
+    source if one succeeded) — missing reviews are encoded as `None`
+    per `docs/SPEC.md` §126; downstream consumers read per-provider
+    entries in `provenance` to see *why*.
 
 ## FM-3 — Instagram / Facebook follower-count scrape blocked
 
@@ -168,8 +189,9 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   - `reviews_google_places` with no key: `status = "not_configured"`,
     `suggestion = "enable Google Places API via GOOGLE_PLACES_API_KEY"`.
   - With key but API rejects: `status = "failed"`.
-  - Top-level `status = "partial"` with
-    `fields_missing = ["reviews.google.count", "reviews.google.rating"]`.
+  - Top-level `status = "partial"`; `data.reviews` left `None` (or
+    carrying a non-Google source if one succeeded). The provenance
+    entry is where downstream reads *why* Google wasn't filled.
 
 ## FM-5 — "Under construction" or redirect to parent brand
 
@@ -184,16 +206,24 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   brief. Caveat: the redirect target is a *different* business entity
   (franchise parent), so some imported facts don't describe the
   prospect's specific location.
-- **Waterfall layer.** Attempt 1 — the need is richer envelope
-  metadata, not a new layer.
-- **Envelope mapping.**
-  - Preserve both `requested_url` and `effective_url` in the envelope
-    (or on `pages`).
-  - Attempt-1 `ProviderRunMetadata.status = "degraded"` when
-    `effective_url` differs from `requested_url` across a brand boundary
-    (heuristic: SLD mismatch).
-  - `suggestion = "site redirected to parent domain; extracted data may
-    describe the parent brand, not this prospect"`.
+- **Waterfall layer.** Attempt 1 — the fetch itself doesn't need a new
+  layer; the envelope needs a way to flag brand identity.
+- **Envelope mapping (today's schema).**
+  - Attempt-1 fetcher: `ProviderRunMetadata.status = "degraded"` when
+    the effective URL differs from the requested URL across a
+    second-level-domain boundary. Detection sits in the fetcher; the
+    degraded status is the only signal today's envelope can emit.
+  - Top-level `status = "partial"`,
+    `error = "cross-brand redirect: extracted data may describe the
+    parent brand, not this prospect"`,
+    `suggestion = "pass the parent-brand domain explicitly if the
+    parent is the intended prospect, or skip"`.
+- **Schema gap.** Surfacing the requested-vs-effective URL pair is a
+  schema evolution — see
+  [§1 Identity preservation on redirect](#1-identity-preservation-on-redirect).
+  Until that lands, downstream consumers only see the degraded status
+  and the `error` string; they cannot tell *which* URL the extractor
+  followed.
 
 ## FM-6 — Services / about content present but unstructured
 
@@ -236,14 +266,23 @@ Envelope enums, for reference (see `docs/SPEC.md`):
 - **Waterfall layer.** Attempt 1 succeeds fetch-wise; no later layer
   helps. The fetch worked; the site just has nothing to extract.
 - **Envelope mapping.**
-  - Attempt-1 `ProviderRunMetadata.status = "ok"`.
-  - Top-level `status = "partial"` with `quality.confidence = "low"`
-    and `fields_missing` populated.
-  - `suggestion = "site is brochureware; downstream synthesis should
-    lean on firmographic data"`.
-  - **Do not map to `degraded` or `failed`** — the fetch succeeded. The
-    distinction between "site blocked us" and "site had nothing" is
-    load-bearing for downstream decisions.
+  - Providers that succeed at their extractor job return
+    `ProviderRunMetadata.status = "ok"` — the fetch worked; the site
+    just has nothing to extract. Empty-but-extracted is valid data.
+  - Providers whose job is to *find* a specific sub-field that isn't
+    present (e.g. `social_discovery_site` finds no handles;
+    `signals_site_heuristic` finds no `team_size_claim`) can
+    legitimately return `status = "degraded"` with an `error` explaining
+    that the source content didn't contain the target.
+  - Top-level `status`:
+    - `"ok"` if every provider returned `ok` (empty outputs are valid).
+    - `"partial"` if any heuristic provider reported `degraded` because
+      the heuristic didn't hit — per SPEC §73, `partial` requires at
+      least one provider to be degraded / failed / not_configured.
+  - **Do not map the fetch itself to `degraded` or `failed`.** The
+    distinction between "site blocked us" (FM-1) and "site had nothing"
+    (FM-7) is load-bearing; it lives in the per-provider `status`
+    values, not in a flattened quality score.
 
 ## FM-8 — Upstream vertical tag disagrees with homepage-inferred vertical
 
@@ -257,16 +296,18 @@ Envelope enums, for reference (see `docs/SPEC.md`):
 - **Agent recovery.** Corrected the classification from homepage text
   mid-research. The correction lives in prose, not in a structured
   field.
-- **Waterfall layer.** Attempt 1 resolves.
-- **Envelope mapping.** This is the canonical "companyctx is a router"
-  signal. Emit a heuristic `vertical_detected` field on
-  `signals_site_heuristic` output and surface a mismatch when upstream
-  firmographics disagree:
-  - Top-level `status = "ok"` with
-    `quality.warnings = ["upstream vertical tag disagrees with
-    homepage-inferred vertical"]`.
-  - The envelope never asserts the "true" vertical — that's a synthesis
-    judgment. It reports the observation.
+- **Waterfall layer.** Attempt 1 resolves the observation itself.
+- **Envelope mapping (today's schema).** There is **no field today**
+  that can carry a vertical observation or the mismatch signal.
+  `HeuristicSignals.tech_vs_claim_mismatches` (SPEC §107) is the
+  closest-shaped slot but it's narrowly scoped to *tech vs claim*, not
+  vertical classification. The transcript shows a real failure; the
+  v0.1 envelope can't surface it.
+- **Schema gap.** See
+  [§2 Vertical observation and firmographics-mismatch warning](#2-vertical-observation-and-firmographics-mismatch-warning).
+  Until that lands, `companyctx` has no way to propagate this signal —
+  the synthesis layer has to infer it from `pages.homepage_text`
+  unaided.
 
 ## FM-9 — Franchise / multi-location ambiguity
 
@@ -282,13 +323,17 @@ Envelope enums, for reference (see `docs/SPEC.md`):
 - **Waterfall layer.** Attempt 3 (Google Places) is the real fix, same
   family as FM-4 but with a subtlety: callers must pass the *location-
   specific* GBP place-id, not just the brand name.
-- **Envelope mapping.**
-  - `reviews.google` carries `scope: "location" | "parent_brand" |
-    "aggregate"` (or equivalent) so downstream callers can distinguish.
-  - When only aggregate is available: `ProviderRunMetadata.status =
-    "degraded"`, top-level `partial`.
-  - `suggestion = "parent-brand aggregate captured; location-level
-    numbers require Google Places API on the specific GBP listing"`.
+- **Envelope mapping (today's schema).**
+  - `reviews_google_places` with no per-location place-id:
+    `ProviderRunMetadata.status = "degraded"`,
+    `error = "only parent-brand aggregate reachable; location-level
+    reviews require per-location GBP place-id"`,
+    `suggestion = "pass the specific GBP place-id for this location"`.
+  - Top-level `status = "partial"`.
+- **Schema gap.** `ReviewSignals` (SPEC §91–94) has no way to mark a
+  value as *location-specific* vs *parent-brand aggregate*; callers
+  can't tell them apart. See
+  [§3 Review-scope distinction (location vs parent-brand aggregate)](#3-review-scope-distinction-location-vs-parent-brand-aggregate).
 
 ## FM-10 — Secondary-source cascade without provenance
 
@@ -303,18 +348,23 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   - `backfill-2026-04-18-command-message-d100-command-m-05ed4365.md:3775`
 - **Waterfall layer.** Cross-cutting — this is a schema concern, not a
   single-attempt concern.
-- **Envelope mapping.** Schema guidance:
-  - Each extracted value that can come from multiple surfaces should be
-    a struct carrying `source_url` + originating `provider_slug`, not a
-    bare scalar. The v0.1 envelope already models per-provider
-    provenance via `ProviderRunMetadata`; reviews / mentions / signals
-    that can spill across surfaces should extend this down to the
-    field level over time.
-  - When a field's value was sourced from a fallback surface rather
-    than the prospect's own domain, top-level `status = "partial"` and
-    `suggestion` should name the swap.
-- **Rationale.** companyctx is MIT and permanent-public. "Deterministic
-  router" loses meaning if provenance is implicit.
+- **Envelope mapping (today's schema).** The v0.1 envelope carries
+  provenance at the *provider* level via `provenance: dict[slug,
+  ProviderRunMetadata]` (SPEC §61–64, §110–118). A `ReviewSignals`
+  value carries `source: str` naming the provider slug that produced
+  it (SPEC §94). There is **no per-field provenance** that can
+  describe "this `services` entry came from the homepage but this one
+  came from a third-party aggregator." Today, if a provider fell back
+  across surfaces internally, that fact is flattened.
+- **Schema gap.** See
+  [§4 Per-field provenance](#4-per-field-provenance). Until it lands,
+  downstream consumers can only see *which provider* produced a
+  value, not *which surface within that provider's reach*.
+- **Rationale.** `companyctx` is MIT and permanent-public.
+  "Deterministic router" carries real weight only when provenance is
+  explicit enough for reviewers to audit. The transcript evidence
+  makes a strong case for field-level provenance; the schema change is
+  non-trivial and belongs in its own issue, not this PR.
 
 ## FM-11 — About-page URL not auto-discovered
 
@@ -331,21 +381,41 @@ Envelope enums, for reference (see `docs/SPEC.md`):
   code (not OSS).
 - **Envelope mapping.**
   - When the `/` fetch succeeds but the about-page URL isn't found:
-    per-provider `status = "degraded"` on a `site_about` sub-provider.
-  - `suggestion = "about-page URL not auto-detected — pass
-    --about-url=<path> or enable the footer anchor-text scan"`.
+    the about-page provider (the provider owning `pages.about_text`)
+    returns `ProviderRunMetadata.status = "degraded"` with
+    `error = "about-page URL not discoverable via anchor heuristics"`.
+  - Top-level `status = "partial"`; `data.pages.about_text` left
+    `None` (it's already declared nullable in SPEC §88).
+  - `suggestion = "about-page URL not auto-detected; synthesis can
+    rely on homepage_text alone or pass an explicit about-URL hint"` —
+    a user-facing hint flag is a CLI evolution, not assumed here.
 
 ## FM-12 — Press / awards discovery needs search, not site fetch
 
-- **Signature.** Briefs cite awards ("2024 NWRA national award"), press
-  ("Forbes Homes #1 Best Gutter Guard 2023"), and credentials ("GentleCure
-  SRT", "Inc. 5000 alum") — almost none of these come from the prospect's
-  own site.
-- **Frequency.** Most high-activity transcripts (10+). Roughly 50% of
-  briefs depend on press-discovery content.
+- **Signature.** Briefs cite awards, media mentions, industry
+  rankings, and external accreditation — sourced via web search rather
+  than the prospect's own domain. The D100 skill's own Phase 1
+  instructions explicitly separate this into a dedicated
+  "web search" step for "media mentions, awards, community presence"
+  distinct from the "website fetch" step.
+- **Frequency.** Appears in most high-activity transcripts. The skill
+  instruction itself ("Web search … for reviews (Google rating +
+  count), media mentions, awards, community presence") is echoed
+  verbatim across 5+ batch transcripts, and the briefs that result
+  consistently include award / press content that did not come from
+  the prospect's own domain.
 - **Evidence.**
-  - `backfill-2026-04-17-command-message-d100-command-m-57f83f37.md:2296`
-  - `backfill-2026-04-18-command-message-d100-command-m-9aea3234.md:854`
+  - `backfill-2026-04-16-command-message-d100-command-m-167f63bc.md:1609`
+    — brief summary for one prospect lists multiple press / award /
+    accreditation signals (a national-magazine category ranking, a
+    BBB rating, an industry list mention, and a national rank) all
+    derived from web search, not the vendor's own site.
+  - `backfill-2026-04-18-command-message-d100-command-m-9aea3234.md:794`
+    — agent explicitly records that it "verified … via fresh web
+    research" to fill award content for a brief.
+  - `backfill-2026-04-18-command-message-d100-command-m-9aea3234.md:403`
+    and siblings — the skill reference itself codifies a search-based
+    step for awards / media mentions as distinct from site fetching.
 - **Waterfall layer.** Distinct from the three site-fetch attempts;
   press discovery is its own pipeline (search-API backed). The day-one
   plumbing is `mentions_brave_stub`; real coverage requires a keyed
@@ -421,9 +491,10 @@ captures how the transcript evidence compares.
 
 - **Google-captcha vs. Google-SPA (FM-4).** Prior taxonomy bundled
   these. Evidence shows the dominant Google failure is structural (GBP
-  is JS-rendered + requires an API), not captcha. Envelope must
-  distinguish `captcha_challenge` from `requires_direct_api` — they
-  suggest different recoveries.
+  is JS-rendered + requires an API), not captcha. In today's envelope
+  the distinction lives in the `error` string + `suggestion` on the
+  degraded provider; recoveries (smart-proxy vs API-key configuration)
+  differ, so the suggestion strings must not be collapsed.
 - **Social handle modes (FM-3, FM-14).** Prior taxonomy framed this as
   "handle misattribution." Transcripts show two separate modes:
   (a) handle not discovered at all (FM-14); (b) handle known but count
@@ -438,13 +509,12 @@ captures how the transcript evidence compares.
   instinct was to build retry/backoff first. Corpus evidence argues
   against it. Invest in Attempt-2 escalation, not Attempt-1 retry
   loops.
-- **Upstream-vertical-misclassification (FM-8) is net new.** Suggests
-  the envelope should emit a `vertical_detected` observation;
-  firmographics lie often enough to matter.
+- **Upstream-vertical-misclassification (FM-8) is net new.** The v0.1
+  envelope cannot propagate this signal; see schema-evolution §2.
 - **Provenance-per-field (FM-10) is net new.** Transcripts silently mix
-  homepage, BBB, Birdeye, press-wire, and search-snippet sources. MIT
-  companyctx must carry per-field provenance for the "deterministic
-  router" claim to hold up in review.
+  homepage, BBB, Birdeye, press-wire, and search-snippet sources. The
+  v0.1 envelope carries provenance per-provider but not per-field; see
+  schema-evolution §4.
 - **Under-construction / redirect shape (FM-5) is net new.** Low
   frequency, clean case — captured so fixtures cover it.
 
@@ -455,12 +525,84 @@ captures how the transcript evidence compares.
   calls out the honest deterministic gaps. Read them together.
 - **For `expected.json` authors.** Each fixture should encode which
   failure mode applies (if any) so the expected envelope's `status`,
-  `error`, and `suggestion` fields are grounded, not guessed. A
-  fixture for a Yelp-blocked prospect should ship the partial envelope
-  this register specifies for FM-2, verbatim.
+  `error`, and `suggestion` fields are grounded, not guessed. Use
+  **only** fields declared in `docs/SPEC.md` §82–108. The
+  schema-evolution proposals below are *not* envelope-available yet
+  and cannot be consumed by fixtures until their own issues land.
 - **For provider implementations.** `ProviderRunMetadata.status`
   transitions are load-bearing. The enum is four-valued on purpose;
   FM-3 and FM-14 argue against collapsing `degraded` into `failed`.
+
+## Schema-evolution proposals (non-normative)
+
+Four transcript-grounded modes cannot be honestly represented by the
+v0.1 envelope. Each is captured here so that follow-up issues can
+propose concrete schema changes. **Nothing in this section is usable by
+`#15` or by fixtures until a separate PR ratifies the schema change.**
+
+### §1 Identity preservation on redirect
+
+**Problem.** FM-5 — when a fetch follows a cross-SLD redirect, the
+extracted `CompanyContext` may describe a different legal entity
+(franchise parent) than the one the caller asked about. The envelope
+has no field that preserves the requested-vs-effective URL pair, so
+downstream consumers cannot tell.
+
+**Candidate shape.** Add something like `pages.requested_url` and
+`pages.effective_url` (both `str`) to `SiteSignals`, or a top-level
+`data.identity` struct. Emit a `ProviderRunMetadata` error when the
+SLDs differ.
+
+**Follow-up.** Worth its own issue.
+
+### §2 Vertical observation and firmographics-mismatch warning
+
+**Problem.** FM-8 — the homepage-inferred vertical (e.g. "portable
+sanitation") can disagree with an upstream firmographics tag (e.g.
+Apollo's "real estate"). The envelope has no field that carries an
+inferred vertical or a mismatch flag. `tech_vs_claim_mismatches` in
+`HeuristicSignals` has the right *shape* (a list of observation
+strings) but is domain-restricted to tech / positioning.
+
+**Candidate shape.** Either (a) broaden `tech_vs_claim_mismatches`
+into a more generic `observations: list[str]` under
+`HeuristicSignals`, or (b) add a dedicated
+`HeuristicSignals.vertical_inferred: str | None` — keeping it an
+observation, per the `docs/SPEC.md` §121–124 "raw observations only"
+rule.
+
+**Follow-up.** Worth its own issue.
+
+### §3 Review-scope distinction (location vs parent-brand aggregate)
+
+**Problem.** FM-9 — `ReviewSignals.count` and `.rating` are flat
+numbers. A franchise child site exposes parent-brand aggregates on its
+homepage; the location's own numbers live in a separate GBP place-id.
+Today the envelope cannot distinguish them, so a synthesis consumer
+can confidently write "5.0 rating, 747 reviews" about what is really
+the parent brand.
+
+**Candidate shape.** Add
+`ReviewSignals.scope: "location" | "parent_brand_aggregate"` (or
+equivalent), and treat aggregate-only runs as `partial`.
+
+**Follow-up.** Worth its own issue.
+
+### §4 Per-field provenance
+
+**Problem.** FM-10 — today's envelope carries provenance at the
+*provider* level. Within a single provider call, a fallback across
+surfaces (homepage → BBB → Birdeye → press wire) collapses to one
+`ProviderRunMetadata` entry. The "deterministic router" positioning
+argues for making the per-field surface explicit.
+
+**Candidate shape.** Either wrap values that can come from multiple
+surfaces in a struct `{value, source_url, extracted_at}`, or extend
+`provenance` with per-path keys. Schema change is non-trivial and
+deserves a focused ADR; transcript evidence (FM-1, FM-2, FM-4 all
+trigger FM-10) makes the case strong.
+
+**Follow-up.** Worth its own issue.
 
 ## What this register does not do
 


### PR DESCRIPTION
## Summary

Mines @joel-req's private partner repo cold-outreach session transcripts to produce two new docs that ground M2 work in *observed* failure modes instead of assumed ones.

- `docs/RISK-REGISTER.md` — 14 Phase 1 web-fetch / extraction failure modes, each with signature, frequency, transcript citation, Waterfall-layer assignment, and envelope mapping (`ProviderRunMetadata.status`, top-level `status`, `error`, `suggestion`).
- `docs/EXTRACTION-STRATEGY.md` — 6 site shapes × extraction approach × honest deterministic gap, with cross-cutting rules for provenance, vertical detection, and press discovery.

Closes #20.

## Evidence base

- **37 session transcripts** on @joel-req's private partner repo at `logs/` + `logs/backfill/`.
- **13** contained substantive Phase 1 activity and were mined; **24** were orchestration shells / MCP pings / out-of-scope (Apollo, Docs, Instantly) and skipped.
- Date range: **2026-04-12 → 2026-04-21** (1 fresh overnight run + 36 backfilled historical runs).
- Niches: gutter installation, real-estate staging, home inspection, IV-therapy wellness, chiropractic, dermatology-aesthetic, window replacement, waste management.
- ~180+ per-prospect sub-agent runs sampled.

## Key analytic calls

- **Strongest transcript-grounded argument for Attempt 3 (Direct-API):** FM-2 (Yelp Fusion) + FM-4 (Google Places). Without Attempt 3, reviews are permanently degraded.
- **Strongest argument for Attempt 2 (smart-proxy):** FM-1 hard 403s on CDN-fronted homepages — unrecoverable by Attempt 1.
- **Contradicts prior taxonomy:** site-fetch timeouts / transient failures are essentially absent (0 occurrences). Invest in Attempt-2 escalation, not Attempt-1 retry loops.
- **New modes not in prior research:** under-construction redirect (FM-5), upstream-vertical-misclassification (FM-8), franchise parent-vs-location ambiguity (FM-9), provenance-per-field (FM-10).
- **Confirms existing OSS-gap flags** for services-list extraction, about-page auto-discovery, and press-release discovery — each with specific transcript evidence.

## Sanitization

companyctx is public MIT. The transcripts contain real business names, owner names, emails, and domains. All quoted evidence in the register is redacted: business → `<site>`, owner → `<owner>`, email → `example.test`, phone → `(555) 555-01XX`. Niche descriptors (the Apify-search verticals) are preserved because they are not per-prospect identifiers.

Leak sweep on diff: no email addresses, phone patterns, real domains (beyond platform hosts `instagram.com` used as extractor-heuristic targets), or owner names present.

Transcripts themselves are **not committed** — they remain in the partner's private repo. Only distilled findings land here.

## Acceptance checklist

- [x] `docs/RISK-REGISTER.md` lists ≥ 8 failure modes (14 delivered) grounded in transcript evidence with per-mode citations.
- [x] `docs/EXTRACTION-STRATEGY.md` maps 4+ site shapes (6 delivered) to extraction approach.
- [x] #15 can reference both docs to justify `expected.json` field-by-field choices.
- [x] No vendor is named in public docs without a measurement citation. Vendor picks already documented elsewhere (`curl_cffi` zero-key, `trafilatura` / `readability-lxml` / `extruct` extractors, Google Places / Yelp Fusion / YouTube Data API) are referenced; no new vendor is introduced.
- [x] PR body lists the transcripts read (count + date range — see Evidence base above).

## Out of scope

- No code changes. This is documentation only. #15 and later provider issues consume these docs.
- No log-mining CLI. One-shot subagent read as the issue permits.
- No rubric-scoring of transcripts against companyctx output (v0.2 golden corpus).

## Test plan

- [x] `python -m ruff format --check .` — 23 files already formatted.
- [x] `python -m ruff check .` — all checks passed.
- [x] `python -m mypy companyctx tests` — success, no issues.
- [x] `python -m pytest -q` — 85 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
