### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `companyctx` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] — 2026-04-21
 
 ### Added
 

--- a/companyctx/__init__.py
+++ b/companyctx/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0"
 
 __all__ = ["__version__"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "companyctx"
-version = "0.1.0.dev0"
+version = "0.1.0"
 description = "Deterministic B2B context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Promotes the package from \`0.1.0.dev0\` to \`0.1.0\`. Single chore commit — no code changes beyond version strings and CHANGELOG's \`[Unreleased]\` → \`[0.1.0] — 2026-04-21\` rename.

## v0.1.0 gating work (all merged)

- #19 — M2 envelope + orchestrator + first zero-key provider
- #31 — curl_cffi adopted as TLS-impersonation library, measured zero-key coverage
- #39 — RISK-REGISTER + EXTRACTION-STRATEGY grounded in real-world evidence
- #41 — 100-site durability report (97% ok on medical/aesthetic SMBs), release-readiness ADR
- #33 — OSS-HYGIENE checklist

## Release gate

Per [\`decisions/2026-04-21-v0.1.0-release-readiness.md\`](decisions/2026-04-21-v0.1.0-release-readiness.md): **GO** with caveats — validated on medical/aesthetic SMBs only; other verticals (gutter/roofing/IV therapy/home services) untested at scale. Real golden corpus (#24) deferred to v0.2.

## What happens on merge

1. This PR merges to \`main\`.
2. \`gh release create v0.1.0 --target main\` creates the tag + GitHub Release, which triggers \`publish.yml\`.
3. The \`pypi\` GitHub Environment's required-reviewer gate pauses the workflow; Devon approves to push to PyPI.
4. \`pip install companyctx==0.1.0\` works after the action completes.

## Test plan

- [ ] CI green on 3.10 / 3.11 / 3.12.
- [ ] Version strings consistent: \`pyproject.toml\`, \`companyctx/__init__.py\`, CHANGELOG heading.