### PR TITLE
docs: drop pre-release / pre-M2 framing post-v0.1.0 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,29 +143,21 @@ context means.
 
 ## Install
 
-Pre-release (name-reservation dev build — CLI commands are stubs that
-exit `2`; useful for pipeline wiring, not for real context yet):
+`v0.1.0` is live on PyPI (first working provider + real `fetch`):
 
 ```bash
 pipx install companyctx
 companyctx --version   # companyctx 0.1.0
-companyctx --help
+companyctx fetch example.com --mock --json
 ```
 
-From source (recommended while M2 is in flight):
+From source:
 
 ```bash
 git clone https://github.com/dmthepm/companyctx.git
 cd companyctx
 pip install -e ".[dev,extract,reviews,youtube]"
 companyctx --help
-```
-
-`v0.1.0` is shipped (first working provider + real `fetch`):
-
-```bash
-pipx install companyctx
-companyctx fetch example.com --mock --json
 ```
 
 ## Design invariants

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ context means.
 ```bash
 pipx install companyctx
 companyctx --version   # companyctx 0.1.0
-companyctx fetch example.com --mock --json
+companyctx fetch acme-bakery.com --mock --json
 ```
 
 From source:

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -59,11 +59,10 @@ zero-key path — the schema doesn't know which layer produced the bytes.
 extras after the measurement spike, but they're interchangeable — swap the
 entry-point line in `pyproject.toml` or override at runtime.
 
-> **v0.1 status.** Only the `SmartProxyProvider` Protocol
+> **v0.1.0 status.** Only the `SmartProxyProvider` Protocol
 > (`companyctx/providers/smart_proxy_base.py`) ships today. The first
-> concrete vendor implementation lands after the M2 zero-key provider
-> (issue #15) and the M2 vendor eval spike — no vendor is named here until
-> measurement is in.
+> concrete vendor implementation lands after the vendor eval spike — no
+> vendor is named here until measurement is in.
 
 ## Provider rules (non-negotiable)
 

--- a/docs/RISK-REGISTER.md
+++ b/docs/RISK-REGISTER.md
@@ -36,7 +36,7 @@ Each failure mode gets:
 - **Waterfall layer** that should cover it (Attempt 1 zero-key stealth,
   Attempt 2 smart-proxy provider, Attempt 3 direct-API provider, or
   a cross-cutting concern).
-- **Envelope mapping** — proposed `ProviderRunMetadata.status`, top-level
+- **Envelope mapping** — `ProviderRunMetadata.status`, top-level
   envelope `status`, `error` template, `suggestion` template.
 - **Agent recovery observed** — what the D100 agent did, and whether it
   was the right thing for `companyctx` to do.

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -3,7 +3,7 @@
 The Pydantic v2 shape `companyctx` emits. The schema is the product — providers
 are replaceable, the contract is not.
 
-Milestone 2 implements the full envelope below. Adding a new optional field is
+The envelope below is the v0.1.0 shape. Adding a new optional field is
 backwards-compatible; removing or renaming a field is a schema-version bump.
 
 ## The envelope


### PR DESCRIPTION
## Summary

Closes #44. `v0.1.0` shipped to PyPI but several docs still carried pre-release framing that was accurate at `0.1.0.dev0`. PR #43 fixed the README hero; this sweep closes the rest.

- **README.md Install** — collapsed the contradictory "Pre-release (name-reservation dev build — CLI commands are stubs that exit 2)" block + later "`v0.1.0` is shipped" block into one coherent section. Dropped "recommended while M2 is in flight" from the source install.
- **docs/SCHEMA.md:6** — "Milestone 2 implements the full envelope below." → "The envelope below is the v0.1.0 shape."
- **docs/RISK-REGISTER.md:39** — dropped "proposed" from the envelope-mapping bullet. The envelope shipped.
- **docs/PROVIDERS.md:62–66** — rewrote the `v0.1 status` note: dropped stale M2 framing (issue #15 closed). Substance unchanged — SmartProxyProvider Protocol ships, concrete vendor still pending the measurement spike.

## Intentional matches left in place (audited, not touched)

- `docs/OSS-HYGIENE.md:42,46,187,189` — rule text / retrospective audit examples. Section 2 pass/fail (lines 42, 46) uses "CLI is stubs — every command exits 2" as the canonical illustration of stale-doc drift the checklist catches. Lines 187, 189 are the audit log item 2 describing the drift that prompted #43 — retrospective, not a current state claim.
- `docs/ZERO-KEY.md:116` — "proposed ADR" in vendor-naming rule text.
- `docs/EXTRACTION-STRATEGY.md:172` — "proposed ADRs can list candidates with a pending-spike banner." Rule text.

## Pre-push gates (all green locally)

- `ruff format --check .` — 27 files already formatted
- `ruff check .` — All checks passed
- `mypy companyctx tests` — no issues found in 22 source files
- `pytest -q` — 89 passed

## Test plan

- [ ] CI green on PR
- [ ] `git grep` for stale pre-release patterns returns only the 4 annotated intentional matches in `OSS-HYGIENE.md`
- [ ] README Install section reads coherently top-to-bottom with no "stubs" / "v0.1.0 is live" contradiction

🤖 Generated with [Claude Code](https://claude.com/claude-code)