### PR TITLE
ci: CI gates — pip-audit + pyroma + Dependabot + CodeQL (closes #30)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot config — see docs/OSS-HYGIENE.md (Automated gates).
+#
+# Weekly sweep. Minor/patch updates grouped into one PR per ecosystem so
+# the queue stays reviewable; major updates surface individually because
+# they can break downstream behavior and deserve human judgment.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    target-branch: main
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - infra
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    target-branch: main
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - infra
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,9 +74,14 @@ jobs:
           pip install pip-audit pyroma
 
       - name: pip-audit (CVE scan on runtime + extras deps)
+        # Split into two steps so a script failure (e.g. malformed
+        # allowlist entry exiting 2) fails the job. Bash `set -e` does
+        # not propagate errors out of $(...) without `inherit_errexit`,
+        # which would silently swallow a bad allowlist and run the
+        # audit with truncated flags.
         run: |
-          IGNORES=$(python scripts/pip_audit_ignores.py)
-          pip-audit --strict $IGNORES
+          python scripts/pip_audit_ignores.py > pip-audit-ignores.args
+          pip-audit --strict $(cat pip-audit-ignores.args)
 
       - name: pyroma (package metadata health, threshold 9/10)
         if: matrix.python-version == '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,22 +49,22 @@ jobs:
     #   (including all provider extras, so a vuln in googlemaps/yelpapi/
     #   etc. still surfaces even though they're optional at runtime).
     #   False positives allowlisted in .pip-audit.toml with cited reasons.
-    # Matrix across the supported Python versions so interpreter-pinned
-    # deps (e.g. tomli on 3.10) are actually covered.
     # pyroma: fails if the package metadata health score drops below 9/10.
-    #   Metadata doesn't vary by interpreter, so it runs once on 3.12.
+    #
+    # Runs on a single Python version. pip-audit and pyroma inspect
+    # installed package metadata, not runtime behavior, so output agrees
+    # across supported interpreters in practice. The one gap is
+    # interpreter-conditional deps (e.g. tomli on 3.10 only) — if a CVE
+    # ever surfaces in one of those, re-matrix this job.
+    name: supply-chain
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
           cache: pip
 
       - name: Install package with all extras + audit tooling
@@ -84,5 +84,4 @@ jobs:
           pip-audit --strict $(cat pip-audit-ignores.args)
 
       - name: pyroma (package metadata health, threshold 9/10)
-        if: matrix.python-version == '3.12'
         run: pyroma -n 9 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,29 +45,39 @@ jobs:
 
   supply-chain:
     # Public-OSS health gates. See docs/OSS-HYGIENE.md (Automated gates).
-    # pip-audit: fails on any known CVE in direct/transitive deps;
-    #   false positives allowlisted in .pip-audit.toml with cited reasons.
+    # pip-audit: fails on any known CVE in direct/transitive deps
+    #   (including all provider extras, so a vuln in googlemaps/yelpapi/
+    #   etc. still surfaces even though they're optional at runtime).
+    #   False positives allowlisted in .pip-audit.toml with cited reasons.
+    # Matrix across the supported Python versions so interpreter-pinned
+    # deps (e.g. tomli on 3.10) are actually covered.
     # pyroma: fails if the package metadata health score drops below 9/10.
+    #   Metadata doesn't vary by interpreter, so it runs once on 3.12.
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
-      - name: Install package + audit tooling
+      - name: Install package with all extras + audit tooling
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[all,dev]"
           pip install pip-audit pyroma
 
-      - name: pip-audit (CVE scan on runtime deps)
+      - name: pip-audit (CVE scan on runtime + extras deps)
         run: |
           IGNORES=$(python scripts/pip_audit_ignores.py)
           pip-audit --strict $IGNORES
 
       - name: pyroma (package metadata health, threshold 9/10)
+        if: matrix.python-version == '3.12'
         run: pyroma -n 9 .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,32 @@ jobs:
 
       - name: Pytest with coverage
         run: pytest tests/ -v --cov=companyctx --cov-report=term-missing --cov-fail-under=70
+
+  supply-chain:
+    # Public-OSS health gates. See docs/OSS-HYGIENE.md (Automated gates).
+    # pip-audit: fails on any known CVE in direct/transitive deps;
+    #   false positives allowlisted in .pip-audit.toml with cited reasons.
+    # pyroma: fails if the package metadata health score drops below 9/10.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package + audit tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install pip-audit pyroma
+
+      - name: pip-audit (CVE scan on runtime deps)
+        run: |
+          IGNORES=$(python scripts/pip_audit_ignores.py)
+          pip-audit --strict $IGNORES
+
+      - name: pyroma (package metadata health, threshold 9/10)
+        run: pyroma -n 9 .

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+# Static analysis via GitHub's default CodeQL. Python catches the library
+# code; actions catches workflow files themselves (injection, expression
+# misuse). Weekly cron runs so stale analyses surface even on quiet weeks.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
+    name: codeql (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage.xml
 out/
 .companyctx-cache/
 .competitor-state-*.json
+pip-audit-ignores.args
 
 # Local secrets
 .env.local

--- a/.pip-audit.toml
+++ b/.pip-audit.toml
@@ -12,5 +12,8 @@
 #
 # When a dependency ships a fixed version, delete the entry rather than
 # leaving stale allowlist items lying around.
-
-ignore = []
+#
+# Leave this file entry-less (only comments) when there is nothing to
+# allowlist — do NOT seed `ignore = []`. TOML rejects mixing a bare
+# array with `[[ignore]]` table-array entries, so an accidental seed
+# breaks the gate the moment someone needs it.

--- a/.pip-audit.toml
+++ b/.pip-audit.toml
@@ -1,0 +1,16 @@
+# pip-audit allowlist.
+#
+# CI fails on any advisory reported by pip-audit. Add an entry here to
+# dismiss a specific advisory that does not apply to companyctx — e.g.
+# the vulnerable code path is not reached from any of our providers.
+# Every entry MUST cite a reason. Empty reasons are rejected in review.
+#
+# Schema:
+#   [[ignore]]
+#   id = "GHSA-xxxx-xxxx-xxxx"  # or "PYSEC-YYYY-NNNN"
+#   reason = "One-line justification, e.g. 'vuln in foo() which we never call'."
+#
+# When a dependency ships a fixed version, delete the entry rather than
+# leaving stale allowlist items lying around.
+
+ignore = []

--- a/docs/OSS-HYGIENE.md
+++ b/docs/OSS-HYGIENE.md
@@ -190,21 +190,30 @@ pyroma gates then gate those PRs just like any human PR.
 
 Runs in the `supply-chain` job alongside ruff / mypy / pytest. Uses the
 `--strict` flag so any advisory against any installed package fails the
-build. Allowlist is `.pip-audit.toml` at repo root.
+build. The job installs `.[all,dev]` so every provider extra
+(`extract`, `reviews`, `youtube`) is audited, not just the default
+runtime deps. The job also matrixes across Python 3.10 / 3.11 / 3.12 so
+interpreter-pinned deps (e.g. `tomli` on 3.10) are actually covered.
 
-To dismiss a false positive:
+Allowlist is `.pip-audit.toml` at repo root. To dismiss a false
+positive:
 
-1. Reproduce locally: `pip-audit $(python scripts/pip_audit_ignores.py)`.
+1. Reproduce locally:
+   `pip-audit --strict $(python scripts/pip_audit_ignores.py)`.
 2. Confirm the vulnerable code path is not reachable from any provider
    or CLI entry point. If it is reachable, the answer is "upgrade the
    dep" or "vendor around it", not allowlist.
-3. Add an entry to `.pip-audit.toml`:
+3. Add an entry to `.pip-audit.toml` as a TOML table-array:
 
    ```toml
    [[ignore]]
    id = "GHSA-xxxx-xxxx-xxxx"
    reason = "vuln in <package>.<symbol>; companyctx calls <other_symbol> only."
    ```
+
+   Do NOT seed the file with `ignore = []`. TOML rejects mixing a bare
+   array with `[[ignore]]` table-array entries, so the allowlist file
+   stays entry-less (comments only) until the first real entry.
 
 4. Cite the advisory ID in your PR description. Reviewers verify the
    unreachable claim before approving.

--- a/docs/OSS-HYGIENE.md
+++ b/docs/OSS-HYGIENE.md
@@ -193,8 +193,11 @@ that owns ruff / mypy / pytest). Uses the `--strict` flag so any
 advisory against any installed package fails the build. The job
 installs `.[all,dev]` so every provider extra
 (`extract`, `reviews`, `youtube`) is audited, not just the default
-runtime deps. The job also matrixes across Python 3.10 / 3.11 / 3.12 so
-interpreter-pinned deps (e.g. `tomli` on 3.10) are actually covered.
+runtime deps. The job runs on a single Python version (3.12) because
+`pip-audit` and `pyroma` inspect package metadata — output agrees
+across supported interpreters in practice. The one gap is
+interpreter-conditional deps (e.g. `tomli` on 3.10 only); if a CVE ever
+surfaces in one of those, re-matrix the job.
 
 Allowlist is `.pip-audit.toml` at repo root. To dismiss a false
 positive:

--- a/docs/OSS-HYGIENE.md
+++ b/docs/OSS-HYGIENE.md
@@ -188,9 +188,10 @@ pyroma gates then gate those PRs just like any human PR.
 
 ### `pip-audit` — CVE scan on direct + transitive deps
 
-Runs in the `supply-chain` job alongside ruff / mypy / pytest. Uses the
-`--strict` flag so any advisory against any installed package fails the
-build. The job installs `.[all,dev]` so every provider extra
+Runs in the `supply-chain` job (parallel to the `lint-type-test` job
+that owns ruff / mypy / pytest). Uses the `--strict` flag so any
+advisory against any installed package fails the build. The job
+installs `.[all,dev]` so every provider extra
 (`extract`, `reviews`, `youtube`) is audited, not just the default
 runtime deps. The job also matrixes across Python 3.10 / 3.11 / 3.12 so
 interpreter-pinned deps (e.g. `tomli` on 3.10) are actually covered.

--- a/docs/OSS-HYGIENE.md
+++ b/docs/OSS-HYGIENE.md
@@ -164,6 +164,92 @@ from `pyproject.toml` and a few sibling files. They rot quickly.*
 
 ---
 
+## Automated gates
+
+Four automated gates run on every PR to catch OSS health drift that
+human review misses at scale. Human review (the eight sections above)
+stays authoritative — the gates are a safety net, not a substitute.
+
+### What runs
+
+| Gate         | Where                           | Trigger                           | Blocks CI? |
+|--------------|---------------------------------|-----------------------------------|------------|
+| `pip-audit`  | `.github/workflows/ci.yml`      | push to `main`, PR                | Yes        |
+| `pyroma`     | `.github/workflows/ci.yml`      | push to `main`, PR                | Yes        |
+| CodeQL       | `.github/workflows/codeql.yml`  | push to `main`, PR, weekly cron   | No\*       |
+| Dependabot   | `.github/dependabot.yml`        | weekly sweep                      | No\*\*     |
+
+\* CodeQL findings surface as Security alerts on the repo. They don't
+fail CI today; branch protection can promote them to blocking in a
+separate repo-settings change (not code).
+
+\*\* Dependabot opens PRs; the same ruff / mypy / pytest / pip-audit /
+pyroma gates then gate those PRs just like any human PR.
+
+### `pip-audit` — CVE scan on direct + transitive deps
+
+Runs in the `supply-chain` job alongside ruff / mypy / pytest. Uses the
+`--strict` flag so any advisory against any installed package fails the
+build. Allowlist is `.pip-audit.toml` at repo root.
+
+To dismiss a false positive:
+
+1. Reproduce locally: `pip-audit $(python scripts/pip_audit_ignores.py)`.
+2. Confirm the vulnerable code path is not reachable from any provider
+   or CLI entry point. If it is reachable, the answer is "upgrade the
+   dep" or "vendor around it", not allowlist.
+3. Add an entry to `.pip-audit.toml`:
+
+   ```toml
+   [[ignore]]
+   id = "GHSA-xxxx-xxxx-xxxx"
+   reason = "vuln in <package>.<symbol>; companyctx calls <other_symbol> only."
+   ```
+
+4. Cite the advisory ID in your PR description. Reviewers verify the
+   unreachable claim before approving.
+
+When the upstream package ships a fix, delete the allowlist entry. Do
+not leave stale entries.
+
+### `pyroma` — package metadata health
+
+Runs with `-n 9` so any score below 9/10 fails CI. Current baseline is
+10/10. A drop usually means a missing classifier, a broken
+`project.urls` entry, or a `long_description` that stopped rendering.
+The fix is always in `pyproject.toml`, not in an allowlist — there is
+no allowlist for pyroma by design.
+
+### CodeQL — static analysis
+
+GitHub's default CodeQL, two languages:
+
+- `python` — catches the library code itself (injection, unsafe
+  deserialization, etc.).
+- `actions` — catches workflow files (expression injection, script
+  injection via untrusted input).
+
+Findings appear on the Security tab. Triage weekly; file an issue for
+anything we can't fix same-day.
+
+### Dependabot — weekly dep sweep
+
+Weekly on Monday 09:00 America/Los_Angeles. Two ecosystems: `pip` and
+`github-actions`. Minor and patch updates group into one PR per
+ecosystem; major updates open individually so a human can judge breakage
+risk. All Dependabot PRs target `main` and pass through the full CI
+gate stack before merge.
+
+### Philosophy
+
+Gates catch drift, not design. Prefer fixing the underlying issue
+(upgrade the dep, fix the metadata, rewrite the vulnerable code path)
+over allowlisting. Allowlist entries cost review attention every time
+someone audits this file — that cost is the point, and it should bias
+us toward real fixes.
+
+---
+
 ## Test case — how PR #19 would have scored
 
 PR [dmthepm/companyctx#19](https://github.com/dmthepm/companyctx/pull/19)

--- a/scripts/pip_audit_ignores.py
+++ b/scripts/pip_audit_ignores.py
@@ -1,0 +1,41 @@
+"""Emit pip-audit --ignore-vuln flags from .pip-audit.toml.
+
+Read by .github/workflows/ci.yml. Run locally with the same invocation
+the CI step uses:
+
+    pip-audit $(python scripts/pip_audit_ignores.py)
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+
+CONFIG = Path(__file__).resolve().parent.parent / ".pip-audit.toml"
+
+
+def main() -> int:
+    if not CONFIG.exists():
+        return 0
+    data = tomllib.loads(CONFIG.read_text(encoding="utf-8"))
+    entries = data.get("ignore", [])
+    for entry in entries:
+        advisory_id = entry.get("id")
+        reason = entry.get("reason", "").strip()
+        if not advisory_id or not reason:
+            print(
+                f"ERROR: .pip-audit.toml entry missing id or reason: {entry!r}",
+                file=sys.stderr,
+            )
+            return 2
+        print("--ignore-vuln", advisory_id)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds four post-v0.1.0 OSS-health gates. No net-new runtime deps.

- **Dependabot** (`.github/dependabot.yml`) — weekly `pip` + `github-actions` sweep, minor/patch grouped, majors individual, commit prefix `chore`.
- **CodeQL** (`.github/workflows/codeql.yml`) — `python` + `actions` languages; push to `main`, PR, weekly Monday cron.
- **`pip-audit`** — new `supply-chain` job in `ci.yml` running `pip-audit --strict`. Allowlist lives in `.pip-audit.toml`; CI reads it via `scripts/pip_audit_ignores.py` and emits `--ignore-vuln` flags. Every entry requires a cited `reason`.
- **`pyroma`** — same job, `pyroma -n 9 .`. Local baseline is 10/10.
- **Docs** — `docs/OSS-HYGIENE.md` gains an *Automated gates* section: what runs, what blocks CI, how to allowlist a false positive.

Local baseline on this branch: `pip-audit` clean (no CVEs, empty allowlist), `pyroma` 10/10.

## Scope boundary
OUT of scope per the issue: release signing (sigstore/cosign), SBOM generation, branch protection / required status checks (repo-settings, not code).

## Test plan
- [x] `ruff format --check .` — 28 files formatted
- [x] `ruff check .` — all checks passed
- [x] `mypy companyctx tests` — no issues (22 source files)
- [x] `pytest -q` — 89 passed
- [x] `pip-audit --strict $(python scripts/pip_audit_ignores.py)` — clean
- [x] `pyroma -n 9 .` — 10/10
- [ ] CI green on PR (matrix 3.10/3.11/3.12 + supply-chain + CodeQL)
- [ ] First Dependabot sweep observed after merge

Closes #30