### PR TITLE
docs: v0.2 honesty pass + providers-list enrichment (#68 Part B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `--from-cache` / `--refresh` / `--no-cache` / `--config` previously were
   accepted silently and ignored. They now raise `typer.BadParameter` with a
-  link to the tracking issue (#37). No silent-pass behavior for contracts
-  the tool does not honour.
+  link to the tracking issue (#9 — SQLite cache schema + migrations; the
+  v0.2.0 messages originally named a phantom tracking number, corrected in
+  the Unreleased block below). No silent-pass behavior for contracts the
+  tool does not honour.
 - `batch` / `cache list` / `cache clear` previously exited 2 with no output.
   They now print `<command> is not implemented in v0.2.0 — see #N` to
   stderr before exiting non-zero.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `companyctx` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`companyctx providers list --json`** — registry introspection as a JSON
+  array (one dict per provider). Columns: `slug`, `tier`
+  (`zero-key` / `smart-proxy` / `direct-api`), `category`, `cost_hint`,
+  `status` (`ready` / `not_configured`), `reason`. Text-mode output gains
+  the same columns. Closes #68 Part B.
+- **Optional `required_env` class var** on providers. `smart_proxy_http`
+  declares `COMPANYCTX_SMART_PROXY_URL`; the CLI surfaces missing entries
+  as `not_configured` + a human-readable reason.
+
+### Changed
+
+- **Docs honesty pass (post-v0.2-tag).** README hero envelope, status
+  block, provider tables, `docs/SPEC.md`, `docs/SCHEMA.md`, `SKILL.md`,
+  and every file in `examples/` now describe the actual shipped v0.2
+  surface (zero-key + smart-proxy + `schema_version` + structured
+  `EnvelopeError`). Reserved-but-deferred features (SQLite cache,
+  `--from-cache` / `--refresh`, `batch`, direct-API providers,
+  `signals_site_heuristic`, `--markdown`) are labelled with tracking
+  issues. Every example's expected-output block and bash / Python
+  script runs clean against `v0.2.0`. Closes #67.
+- **`fetch --markdown` help text** explicitly labels the flag
+  experimental + not implemented in v0.2 (already rejects at runtime).
+- **Examples now resolve `fixtures/` relative to the script** instead of
+  `Path("fixtures")` so `06-competitor-monitor.py`,
+  `07-inbound-webhook-enrichment/main.py`, and `08-support-ticket-context.py`
+  run clean from any CWD.
+
 ## [0.2.0] — 2026-04-22
 
 ### Changed — BREAKING (envelope schema)

--- a/README.md
+++ b/README.md
@@ -13,26 +13,32 @@ companyctx fetch acme-bakery.com --json
 
 ```json
 {
-  "schema_version": "0.2.0",
-  "status": "ok",
   "data": {
-    "site": "acme-bakery.com",
     "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "mentions": null,
     "pages": {
-      "homepage_text": "Acme Bakery is a bakery in Portland, OR. Founded 2010. We're a team of 3. ...",
       "about_text": "Acme Bakery has served Portland, OR since 2010. ...",
+      "homepage_text": "Acme Bakery is a bakery in Portland, OR. Founded 2010. We're a team of 3. ...",
       "services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
       "tech_stack": ["WordPress", "Elementor"]
     },
     "reviews": null,
-    "social": null,
     "signals": null,
-    "mentions": null
+    "site": "acme-bakery.com",
+    "social": null
   },
+  "error": null,
   "provenance": {
-    "site_text_trafilatura": { "status": "ok", "latency_ms": 412, "error": null, "provider_version": "0.1.0", "cost_incurred": 0 }
+    "site_text_trafilatura": {
+      "cost_incurred": 0,
+      "error": null,
+      "latency_ms": 412,
+      "provider_version": "0.1.0",
+      "status": "ok"
+    }
   },
-  "error": null
+  "schema_version": "0.2.0",
+  "status": "ok"
 }
 ```
 
@@ -155,15 +161,15 @@ On full block with no Attempt-2/3 providers configured:
 
 ```json
 {
-  "schema_version": "0.2.0",
-  "status": "partial",
-  "data": { "site": "example.com", "fetched_at": "...", "pages": null, "reviews": null, ... },
-  "provenance": { "site_text_trafilatura": { "status": "failed", "error": "blocked_by_antibot (HTTP 403)", ... } },
+  "data": { "fetched_at": "...", "mentions": null, "pages": null, "reviews": null, "signals": null, "site": "example.com", "social": null },
   "error": {
     "code": "blocked_by_antibot",
     "message": "blocked_by_antibot (HTTP 403)",
     "suggestion": "configure a smart-proxy provider key or skip this prospect"
-  }
+  },
+  "provenance": { "site_text_trafilatura": { "cost_incurred": 0, "error": "blocked_by_antibot (HTTP 403)", "latency_ms": 842, "provider_version": "0.1.0", "status": "failed" } },
+  "schema_version": "0.2.0",
+  "status": "partial"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,35 +17,89 @@ companyctx fetch acme-bakery.com --json
   "status": "ok",
   "data": {
     "site": "acme-bakery.com",
-    "fetched_at": "2026-04-20T18:42:11Z",
-    "pages":   { "homepage_text": "...", "services": ["cakes", "catering"], "tech_stack": ["WordPress", "Elementor"] },
-    "reviews": { "count": 142, "rating": 4.6, "source": "reviews_google_places" },
-    "social":  { "handles": { "instagram": "@acmebakery" }, "follower_counts": {} },
-    "signals": { "copyright_year": 2024, "last_blog_post_at": "2026-02-11T00:00:00Z", "team_size_claim": "team of 6" }
+    "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "pages": {
+      "homepage_text": "Acme Bakery is a bakery in Portland, OR. Founded 2010. We're a team of 3. ...",
+      "about_text": "Acme Bakery has served Portland, OR since 2010. ...",
+      "services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
+      "tech_stack": ["WordPress", "Elementor"]
+    },
+    "reviews": null,
+    "social": null,
+    "signals": null,
+    "mentions": null
   },
   "provenance": {
-    "site_text_trafilatura": { "status": "ok",            "latency_ms": 412, "error": null,                       "provider_version": "0.1.0" },
-    "reviews_google_places": { "status": "not_configured","latency_ms": 0,   "error": "GOOGLE_PLACES_API_KEY not set", "provider_version": "0.1.0" }
+    "site_text_trafilatura": { "status": "ok", "latency_ms": 412, "error": null, "provider_version": "0.1.0", "cost_incurred": 0 }
   },
   "error": null
 }
 ```
 
 One site in. One schema-locked JSON object out. No API keys for the
-zero-key path. Graceful partials on anti-bot blocks. A local SQLite cache
-that compounds into a queryable B2B dataset over time.
+zero-key path. Graceful partials on anti-bot blocks. The envelope is
+versioned via a top-level `schema_version` field so agents can branch on
+shape without substring-parsing.
 
-> **Status:** `v0.2.0` is the current release (schema-breaking envelope bump:
-> structured `EnvelopeError` + top-level `schema_version`; see
-> [`CHANGELOG.md`](CHANGELOG.md)). The zero-key provider
-> (`site_text_trafilatura`) is wired end-to-end: `companyctx fetch <site> --json`
-> returns a schema-locked `Envelope` with `pages.homepage_text` / `about_text` /
-> `services`. Measured 97% envelope-`ok` rate on a 100-site real-world sample
-> (v0.1.0 baseline; re-measurement lands with the post-v0.2 docs pass).
-> Schema + CLI surface in [`docs/SPEC.md`](docs/SPEC.md) and
-> [`docs/SCHEMA.md`](docs/SCHEMA.md); architecture in
-> [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md); release-readiness ADR in
-> [`decisions/2026-04-21-v0.1.0-release-readiness.md`](decisions/2026-04-21-v0.1.0-release-readiness.md).
+`reviews` / `social` / `signals` / `mentions` are reserved in the
+`CompanyContext` schema; the providers that populate them (Google Places,
+YouTube Data, the site-heuristic provider) are roadmap work — see
+[Status](#status) below. Today a real run returns `pages.*` plus nulls,
+which is what the `--mock` fixture tree reproduces byte-for-byte.
+
+## Status
+
+`v0.2.0` is the current release. What's shipped:
+
+- **Envelope contract** — `{schema_version, status, data, provenance, error?}`
+  with `status ∈ {ok, partial, degraded}` and a structured `EnvelopeError`
+  (`{code, message, suggestion}`) on non-`ok` runs. `extra="forbid"` on every
+  model. See [`docs/SCHEMA.md`](docs/SCHEMA.md).
+- **Zero-key Attempt 1** — `site_text_trafilatura` (TLS-impersonated fetch
+  via `curl_cffi` + trafilatura extraction). Populates `data.pages.*`
+  (`homepage_text`, `about_text`, `services`, `tech_stack`). 20/20 envelope-`ok`
+  on a shape-balanced zero-key probe at a fresh Chrome fingerprint; see
+  [`docs/ZERO-KEY.md`](docs/ZERO-KEY.md).
+- **Smart-proxy Attempt 2** — `smart_proxy_http` (vendor-agnostic URL-style
+  proxy). User supplies `COMPANYCTX_SMART_PROXY_URL`; env-unset surfaces as
+  `not_configured` with an actionable suggestion rather than a crash. Named-
+  vendor adapter lands after the smart-proxy vendor eval (tracking: #63).
+- **CLI verbs** — `fetch`, `schema` (emits Draft 2020-12 JSON Schema),
+  `validate`, `providers list` (with `--json`, waterfall tier, config
+  status, reason).
+- **`py.typed` marker + public-API re-exports** — `from companyctx import
+  Envelope, EnvelopeError, CompanyContext, ...` works straight off the
+  package root; downstream `mypy` sees concrete types.
+
+What's **not** shipped yet and is explicitly deferred (the CLI surface
+rejects these flags with a tracking-issue pointer rather than silently
+accepting them):
+
+- **SQLite fetch cache** (`--from-cache` / `--refresh` / `--no-cache` /
+  `--config`) — tracked in #9.
+- **`batch <csv>`** — stub, prints an error and exits non-zero.
+- **Direct-API (Attempt 3) providers** — Google Places (tracking: #7),
+  Yelp Fusion, YouTube Data, Brave Search (mentions tracking: #58). None
+  registered in v0.2; `data.reviews` / `data.social` / `data.mentions`
+  stay null on live runs until a direct-API provider lands.
+- **Site-heuristic `signals` provider** — planned alongside the direct-API
+  slate; populates `data.signals.copyright_year`, `last_blog_post_at`,
+  `team_size_claim`.
+- **`companyctx fetch --markdown`** — experimental flag labelled in help
+  text; runs fail fast. Markdown output belongs in a downstream synthesis
+  step, not here (tracking: #68).
+
+Measured 97% envelope-`ok` rate on a 100-site real-world sample on the
+v0.1 zero-key baseline; post-v0.2 re-measurement tracks under the durability
+rerun (#61). Full breakdown in
+[`research/2026-04-21-tls-impersonation-spike.md`](research/2026-04-21-tls-impersonation-spike.md)
+and [`docs/ZERO-KEY.md`](docs/ZERO-KEY.md).
+
+Schema + CLI surface in [`docs/SPEC.md`](docs/SPEC.md) and
+[`docs/SCHEMA.md`](docs/SCHEMA.md); architecture in
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md);
+release-readiness ADR in
+[`decisions/2026-04-21-v0.1.0-release-readiness.md`](decisions/2026-04-21-v0.1.0-release-readiness.md).
 
 ## What this is (and isn't)
 
@@ -56,10 +110,12 @@ that compounds into a queryable B2B dataset over time.
 - **A Deterministic Waterfall.** Zero-key stealth fetch first →
   smart-proxy provider (if configured) → direct-API provider (if
   configured). Every attempt returns the same shape.
-- **A local-first memory layer.** The SQLite cache is not just speed — it
-  compounds into a queryable local B2B dataset as a byproduct of normal use.
 - **A narrow muscle in the brains-and-muscles pattern.** Your frontier
   model is the brain; `companyctx` is one of many CLIs it pipes through.
+- **A local-first memory layer — by design, landing later.** The SQLite
+  cache is scoped as Vertical Memory: a queryable local B2B dataset that
+  compounds as a byproduct of normal use. It is **not wired in v0.2** —
+  `--from-cache` / `--refresh` are deferred to #9.
 
 ### ISN'T
 
@@ -135,18 +191,21 @@ Numbers come from measurement, not marketing.
 
 ```bash
 companyctx fetch acme-bakery.com --json \
-  | jq '.data | {site, signals, reviews}' \
+  | jq '.data.pages | {services, tech_stack, homepage: .homepage_text[:280]}' \
   | claude -p "write a 6-section outreach brief from this context"
 ```
 
 ```python
 import json, subprocess
 ctx = json.loads(subprocess.check_output(["companyctx", "fetch", "acme-bakery.com", "--json"]))
-if ctx["status"] == "partial":
-    err = ctx["error"]
-    print(f"heads up: {err['code']} — {err['message']} → {err.get('suggestion')}")
+if ctx["status"] != "ok":
+    err = ctx["error"] or {}
+    print(f"heads up: {err.get('code')} — {err.get('message')} → {err.get('suggestion')}")
 brief = synthesize(ctx["data"])   # your synthesis call, your prompts, your weights
 ```
+
+Branch on `status` (not on try/except). Branch on `error.code` (closed
+enum), not on substring-matching `error.message`.
 
 `companyctx` never calls an LLM. The brain upstream decides what the
 context means.
@@ -178,34 +237,46 @@ companyctx --help
 - **Graceful-partial always.** Providers never raise uncaught. Every
   failure maps to `ProviderRunMetadata.status` per provider and the
   top-level `status` on the envelope.
-- **Vertical Memory.** Every run persists the full normalized payload to
-  SQLite under [XDG paths](https://specifications.freedesktop.org/basedir-spec/).
-  `--refresh` forces a re-fetch; `--from-cache` is a cache-only read.
-  A `companyctx query ...` DSL on the cache is v0.2 scope, not v0.1.
+- **Vertical Memory (design invariant, not yet wired).** The SQLite cache
+  is designed to compound into a queryable local B2B dataset under
+  [XDG paths](https://specifications.freedesktop.org/basedir-spec/); the
+  schema-versioned migrations and `--refresh` / `--from-cache` flags are
+  reserved in the CLI surface but not implemented in v0.2 — they reject
+  with a tracking-issue pointer (#9).
 - **Provider pluggability.** Every deterministic call class is discovered
-  via Python entry points (`companyctx.providers`). Day-one providers
-  include bus-factor fallbacks (`trafilatura` + `readability-lxml` both
-  wired for site text). See [`docs/PROVIDERS.md`](docs/PROVIDERS.md).
+  via Python entry points (`companyctx.providers`). v0.2 ships
+  `site_text_trafilatura` (zero-key) and `smart_proxy_http` (user-keyed,
+  vendor-agnostic). Direct-API providers (Google Places, Yelp, YouTube,
+  Brave) and the `readability-lxml` bus-factor fallback are scaffolded for
+  later milestones. See [`docs/PROVIDERS.md`](docs/PROVIDERS.md).
 - **robots.txt respected by default.** `--ignore-robots` is an explicit
   CLI-only flag; never settable via TOML or env.
 - **Deterministic mocks.** `fixtures/<site>/` drives `--mock`; re-runs
   produce byte-identical output modulo `fetched_at`.
 
-## Providers (committed for v0.1)
+## Providers
 
-| Slug | Layer | Category | Key | Cost |
+Shipped in v0.2 (run `companyctx providers list` to introspect):
+
+| Slug | Tier | Category | Key | Cost |
 |---|---|---|---|---|
-| `site_text_trafilatura` | Zero-key | site_text | — | free |
-| `site_text_readability` | Zero-key | site_text (fallback) | — | free |
-| `site_meta_extruct` | Zero-key | site_meta | — | free |
-| `social_discovery_site` | Zero-key | social_discovery | — | free |
-| `signals_site_heuristic` | Zero-key | signals | — | free |
-| `reviews_google_places` | Direct-API | reviews | `GOOGLE_PLACES_API_KEY` | per-1k |
-| `reviews_yelp_fusion` | Direct-API | reviews | `YELP_API_KEY` | per-call |
-| `social_counts_youtube` | Direct-API | social_counts | `YOUTUBE_API_KEY` | free w/ quota |
-| `mentions_brave_stub` | Direct-API | mentions | `BRAVE_SEARCH_API_KEY` | per-call |
+| `site_text_trafilatura` | zero-key | site_text | — | free |
+| `smart_proxy_http` | smart-proxy | smart_proxy | `COMPANYCTX_SMART_PROXY_URL` | per-call |
 
-Full table + `SmartProxyProvider` interface in
+Scaffolded / deferred (roadmap):
+
+| Slug | Tier | Category | Tracking |
+|---|---|---|---|
+| `site_text_readability` | zero-key | site_text (fallback) | bus-factor fallback, lands alongside fallback wiring |
+| `site_meta_extruct` | zero-key | site_meta | future milestone |
+| `social_discovery_site` | zero-key | social_discovery | future milestone |
+| `signals_site_heuristic` | zero-key | signals | future milestone |
+| `reviews_google_places` | direct-api | reviews | #7 |
+| `reviews_yelp_fusion` | direct-api | reviews | future milestone |
+| `social_counts_youtube` | direct-api | social_counts | future milestone |
+| `mentions_brave_stub` | direct-api | mentions | #58 |
+
+Full rationale + the `SmartProxyProvider` interface in
 [`docs/PROVIDERS.md`](docs/PROVIDERS.md).
 
 ## Layout
@@ -213,17 +284,21 @@ Full table + `SmartProxyProvider` interface in
 ```
 companyctx/            # package
   cli.py               # Typer app
+  core.py              # Deterministic Waterfall orchestrator (Attempt 1 + 2)
   schema.py            # pydantic v2 models — the JSON contract
-  config.py            # pydantic-settings + TOML, XDG-compliant paths
-  cache.py             # SQLite fetch cache (Vertical Memory)
-  http.py              # stealth fetcher foundation
+  extract.py           # HTML → SiteSignals extractor shared by zero-key + smart-proxy
+  http.py              # stealth fetcher helpers
   robots.py            # robots.txt enforcement
+  security.py          # SSRF + response-cap + redirect guardrails
   providers/
     __init__.py        # plugin loader (importlib.metadata.entry_points)
-    base.py            # ProviderBase, ProviderError, ProviderRunMetadata
+    base.py            # ProviderBase protocol + FetchContext + Literal category enum
+    site_text_trafilatura.py    # Attempt 1 — zero-key homepage extraction
+    smart_proxy_http.py         # Attempt 2 — vendor-agnostic smart proxy
+    smart_proxy_base.py         # shared helpers for smart-proxy providers
 SKILL.md               # ~150-token agent-discovery surface (not MCP)
 docs/
-  SPEC.md              # frozen v0.1 spec snapshot
+  SPEC.md              # frozen spec snapshot (v0.2 envelope)
   SCHEMA.md            # Pydantic envelope in detail
   ARCHITECTURE.md      # brains-and-muscles + Deterministic Waterfall + Vertical Memory
   ZERO-KEY.md          # honest anti-bot coverage + graceful-partial contract
@@ -231,7 +306,7 @@ docs/
   VALIDATION.md        # two-phase acceptance protocol
   REFERENCES.md        # upstream OSS deps
 decisions/             # in-repo ADRs (walks-the-walk for OSS readers)
-fixtures/              # per-site raw HTML + API responses + expected.json
+fixtures/              # per-site raw HTML + expected.json (drives --mock)
 tests/                 # pytest, hypothesis where useful
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,10 +5,11 @@ schema-locked JSON envelope out. Zero keys on the default path.
 
 **Commands.**
 
-- `companyctx fetch <site> --json` — run all providers; emit one envelope.
-- `companyctx schema` — emit the envelope's JSON Schema to stdout.
-- `companyctx providers list` — show providers + status + cost hint.
-- `companyctx validate <path.json>` — round-trip through the pydantic schema.
+- `companyctx fetch <site> --json` — run the waterfall; emit one envelope.
+- `companyctx schema` — emit the envelope's Draft 2020-12 JSON Schema.
+- `companyctx providers list --json` — registered providers as JSON
+  (`slug`, `tier`, `category`, `cost_hint`, `status`, `reason`).
+- `companyctx validate <path.json>` — round-trip through the Pydantic schema.
 
 **Rules for agents.**
 
@@ -21,15 +22,52 @@ schema-locked JSON envelope out. Zero keys on the default path.
   no_provider_succeeded | misconfigured_provider`).
 - Pipe stdout; don't parse logs. The JSON envelope is the contract.
 - The `data.site` field is the identifier; `data.pages` holds homepage-
-  derived content; `data.reviews` / `data.social` / `data.signals` /
-  `data.mentions` fill the rest of the schema.
+  derived content (`homepage_text`, `about_text`, `services`, `tech_stack`).
+- `data.reviews` / `data.social` / `data.signals` / `data.mentions` are
+  reserved in the schema but stay `null` in v0.2 — the providers that
+  fill them are deferred (see `docs/SPEC.md`). Schema-locked partials,
+  not bugs.
 
-**Example.**
+**Envelope shape (v0.2).**
+
+```json
+{
+  "schema_version": "0.2.0",
+  "status": "ok",
+  "data": {
+    "site": "acme-bakery.com",
+    "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "pages": {
+      "homepage_text": "...",
+      "about_text": "...",
+      "services": ["..."],
+      "tech_stack": ["..."]
+    },
+    "reviews": null,
+    "social": null,
+    "signals": null,
+    "mentions": null
+  },
+  "provenance": {
+    "site_text_trafilatura": {
+      "status": "ok",
+      "latency_ms": 412,
+      "error": null,
+      "provider_version": "0.1.0",
+      "cost_incurred": 0
+    }
+  },
+  "error": null
+}
+```
+
+**Example pipe.**
 
 ```bash
 companyctx fetch acme-bakery.com --json \
-  | jq '.data | {site, signals, reviews}'
+  | jq '.data.pages | {services, tech_stack}'
 ```
 
-See `docs/SCHEMA.md` for the full envelope and `docs/ZERO-KEY.md` for the
+See `docs/SCHEMA.md` for the full envelope, `docs/SPEC.md` for the CLI
+surface (including deferred commands), and `docs/ZERO-KEY.md` for the
 honest anti-bot coverage matrix.

--- a/SKILL.md
+++ b/SKILL.md
@@ -32,32 +32,32 @@ schema-locked JSON envelope out. Zero keys on the default path.
 
 ```json
 {
-  "schema_version": "0.2.0",
-  "status": "ok",
   "data": {
-    "site": "acme-bakery.com",
     "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "mentions": null,
     "pages": {
-      "homepage_text": "...",
       "about_text": "...",
+      "homepage_text": "...",
       "services": ["..."],
       "tech_stack": ["..."]
     },
     "reviews": null,
-    "social": null,
     "signals": null,
-    "mentions": null
+    "site": "acme-bakery.com",
+    "social": null
   },
+  "error": null,
   "provenance": {
     "site_text_trafilatura": {
-      "status": "ok",
-      "latency_ms": 412,
+      "cost_incurred": 0,
       "error": null,
+      "latency_ms": 412,
       "provider_version": "0.1.0",
-      "cost_incurred": 0
+      "status": "ok"
     }
   },
-  "error": null
+  "schema_version": "0.2.0",
+  "status": "ok"
 }
 ```
 

--- a/companyctx/cli.py
+++ b/companyctx/cli.py
@@ -17,6 +17,7 @@ pass.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any
@@ -26,6 +27,7 @@ from pydantic import ValidationError
 
 from companyctx import __version__, core
 from companyctx.providers import discover
+from companyctx.providers.base import ProviderBase
 from companyctx.schema import Envelope
 
 app = typer.Typer(
@@ -118,7 +120,20 @@ _VERSION_OPT = typer.Option(
 _SITE_ARG = typer.Argument(..., help="The prospect site, e.g. example.com or https://example.com")
 _OUT_OPT_FILE = typer.Option(None, "--out", help="Write JSON to this path.")
 _OUT_OPT_DIR = typer.Option(..., "--out", help="Output directory.")
-_FORMAT_OPT = typer.Option(True, "--json/--markdown", help="Output format.")
+_FORMAT_OPT = typer.Option(
+    True,
+    "--json/--markdown",
+    help=(
+        "Output format. --json is the supported contract. "
+        "--markdown is experimental and not implemented in v0.2.0 — "
+        "runs fail fast (see issue #68)."
+    ),
+)
+_PROVIDERS_JSON_OPT = typer.Option(
+    False,
+    "--json",
+    help="Emit the registry as a JSON array (one dict per provider).",
+)
 _NO_CACHE_OPT = typer.Option(
     False,
     "--no-cache",
@@ -286,22 +301,92 @@ def cache_clear(
     _fail_stub("cache clear", _CACHE_ISSUE)
 
 
+# Waterfall-tier mapping for the provider registry. The orchestrator runs
+# providers in three bands — zero-key (Attempt 1), smart-proxy (Attempt 2),
+# and direct-API (Attempt 3) — and ``providers list`` surfaces the band next
+# to each slug so users can see the waterfall shape without reading the code.
+_TIER_BY_CATEGORY: dict[str, str] = {
+    "site_text": "zero-key",
+    "site_meta": "zero-key",
+    "social_discovery": "zero-key",
+    "signals": "zero-key",
+    "smart_proxy": "smart-proxy",
+    "reviews": "direct-api",
+    "social_counts": "direct-api",
+    "mentions": "direct-api",
+}
+
+
+def _provider_config_status(cls: type[ProviderBase]) -> tuple[str, str | None]:
+    """Return ``(status, reason)`` for a provider's runtime configuration.
+
+    A provider declares runtime-required env vars via the optional
+    ``required_env: ClassVar[tuple[str, ...]]`` attribute. Missing entries
+    surface as ``not_configured`` with a human-readable reason; zero-key
+    providers with no declared env vars report ``ready``.
+    """
+    required_env = tuple(getattr(cls, "required_env", ()))
+    if not required_env:
+        return "ready", None
+    missing = [name for name in required_env if not os.environ.get(name, "").strip()]
+    if not missing:
+        return "ready", None
+    return "not_configured", f"missing env: {', '.join(missing)}"
+
+
+def _provider_row(slug: str, cls: type[ProviderBase]) -> dict[str, str | None]:
+    category = str(getattr(cls, "category", "?"))
+    status, reason = _provider_config_status(cls)
+    return {
+        "slug": slug,
+        "tier": _TIER_BY_CATEGORY.get(category, "unknown"),
+        "category": category,
+        "cost_hint": str(getattr(cls, "cost_hint", "?")),
+        "status": status,
+        "reason": reason,
+    }
+
+
 @providers_app.command("list")
-def providers_list() -> None:
-    """Show registered providers, their category, and cost hint."""
+def providers_list(json_out: bool = _PROVIDERS_JSON_OPT) -> None:
+    """Show registered providers with waterfall tier, config status, and reason.
+
+    The text table is the human-first shape. ``--json`` emits a JSON array of
+    ``{slug, tier, category, cost_hint, status, reason}`` dicts — agents and
+    scripts should consume the JSON form.
+    """
     registry = discover()
+    if json_out:
+        payload = [_provider_row(slug, registry[slug]) for slug in sorted(registry)]
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        return
     if not registry:
         typer.echo("(no providers registered)")
         return
-    rows: list[tuple[str, str, str]] = []
-    for slug in sorted(registry):
-        cls = registry[slug]
-        category = getattr(cls, "category", "?")
-        cost_hint = getattr(cls, "cost_hint", "?")
-        rows.append((slug, str(category), str(cost_hint)))
-    width = max(len(r[0]) for r in rows)
-    for slug, category, cost_hint in rows:
-        typer.echo(f"{slug.ljust(width)}  {category:<18}  {cost_hint}")
+    rows = [_provider_row(slug, registry[slug]) for slug in sorted(registry)]
+    headers = {
+        "slug": "SLUG",
+        "tier": "TIER",
+        "category": "CATEGORY",
+        "cost_hint": "COST",
+        "status": "STATUS",
+        "reason": "REASON",
+    }
+    widths = {
+        key: max(len(headers[key]), *(len(str(row[key] or "-")) for row in rows)) for key in headers
+    }
+    typer.echo(
+        "  ".join(headers[key].ljust(widths[key]) for key in ("slug", "tier", "category"))
+        + "  "
+        + "  ".join(headers[key].ljust(widths[key]) for key in ("cost_hint", "status", "reason"))
+    )
+    for row in rows:
+        typer.echo(
+            "  ".join(
+                str(row[key] or "-").ljust(widths[key])
+                for key in ("slug", "tier", "category", "cost_hint", "status", "reason")
+            )
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/companyctx/cli.py
+++ b/companyctx/cli.py
@@ -6,8 +6,8 @@ Exposes the public contract described in ``docs/SPEC.md``:
 - ``schema`` — print the envelope's JSON Schema (Draft 2020-12) to stdout.
 - ``validate <path>`` — round-trip a JSON envelope through the schema.
 - ``providers list`` — show registered providers with status + cost hint.
-- ``cache list`` / ``cache clear`` — Vertical Memory plumbing (see issue #37).
-- ``batch <csv>`` — batch mode (see issue #38).
+- ``cache list`` / ``cache clear`` — Vertical Memory plumbing (see issue #9).
+- ``batch <csv>`` — batch mode (lands alongside cache; see issue #9).
 
 Several flags and subcommands in v0.2 are stubs. They fail loudly rather than
 silently accepting input and doing nothing — see issue #68 for the honesty
@@ -54,9 +54,11 @@ app.add_typer(providers_app, name="providers")
 
 # Tracking-issue links for honesty-mode rejections. Each stub command / flag
 # carries its own issue so users who hit the wall can follow progress.
-_CACHE_ISSUE = 37
-_BATCH_ISSUE = 38
-_CONFIG_ISSUE = 37
+# Cache, --config (TOML loader), and `batch` all block on the SQLite + config
+# layer tracked under issue #9.
+_CACHE_ISSUE = 9
+_BATCH_ISSUE = 9
+_CONFIG_ISSUE = 9
 
 
 def _version_callback(value: bool) -> None:
@@ -137,13 +139,13 @@ _PROVIDERS_JSON_OPT = typer.Option(
 _NO_CACHE_OPT = typer.Option(
     False,
     "--no-cache",
-    help="Bypass the fetch cache. (Not implemented in v0.2.0 — see issue #37.)",
+    help="Bypass the fetch cache. (Not implemented in v0.2.0 — see issue #9.)",
     callback=_reject_cache_flag("--no-cache", _CACHE_ISSUE),
 )
 _CONFIG_OPT = typer.Option(
     None,
     "--config",
-    help="TOML config path. (Not implemented in v0.2.0 — see issue #37.)",
+    help="TOML config path. (Not implemented in v0.2.0 — see issue #9.)",
     callback=_reject_config_flag,
 )
 _MOCK_FETCH_OPT = typer.Option(
@@ -164,13 +166,13 @@ _IGNORE_ROBOTS_OPT = typer.Option(
 _REFRESH_OPT = typer.Option(
     False,
     "--refresh",
-    help="Ignore cache and re-fetch. (Not implemented in v0.2.0 — see issue #37.)",
+    help="Ignore cache and re-fetch. (Not implemented in v0.2.0 — see issue #9.)",
     callback=_reject_cache_flag("--refresh", _CACHE_ISSUE),
 )
 _FROM_CACHE_OPT = typer.Option(
     False,
     "--from-cache",
-    help="Return only the cached payload. (Not implemented in v0.2.0 — see issue #37.)",
+    help="Return only the cached payload. (Not implemented in v0.2.0 — see issue #9.)",
     callback=_reject_cache_flag("--from-cache", _CACHE_ISSUE),
 )
 _CSV_ARG = typer.Argument(..., help="CSV of sites.")
@@ -264,7 +266,7 @@ def batch(
     mock: bool = _MOCK_BATCH_OPT,  # noqa: ARG001 — stub
     verbose: bool = _VERBOSE_OPT,  # noqa: ARG001 — stub
 ) -> None:
-    """Run fetch over a CSV of sites. (Stub — see issue #38.)"""
+    """Run fetch over a CSV of sites. (Stub — see issue #9.)"""
     _fail_stub("batch", _BATCH_ISSUE)
 
 
@@ -288,7 +290,7 @@ def validate(
 
 @cache_app.command("list")
 def cache_list() -> None:
-    """List cache entries. (Stub — see issue #37.)"""
+    """List cache entries. (Stub — see issue #9.)"""
     _fail_stub("cache list", _CACHE_ISSUE)
 
 
@@ -297,7 +299,7 @@ def cache_clear(
     site: str | None = _CACHE_SITE_OPT,  # noqa: ARG001 — stub
     older_than: str | None = _CACHE_OLDER_OPT,  # noqa: ARG001 — stub
 ) -> None:
-    """Prune the cache. (Stub — see issue #37.)"""
+    """Prune the cache. (Stub — see issue #9.)"""
     _fail_stub("cache clear", _CACHE_ISSUE)
 
 

--- a/companyctx/providers/smart_proxy_http.py
+++ b/companyctx/providers/smart_proxy_http.py
@@ -64,6 +64,10 @@ class Provider:
     category: ClassVar[Literal["smart_proxy"]] = "smart_proxy"
     cost_hint: ClassVar[Literal["per-call"]] = "per-call"
     version: ClassVar[str] = _VERSION
+    # Environment variables the provider needs before it can run. ``providers
+    # list`` surfaces missing entries as a ``not_configured`` row with an
+    # actionable reason so users see the wiring gap before the first fetch.
+    required_env: ClassVar[tuple[str, ...]] = (ENV_URL,)
 
     def fetch(
         self,

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -61,14 +61,74 @@ Agents should branch on `error.code`; humans read `error.message`.
 `"skip this prospect"`. Additional codes are added in minor releases and bump
 `schema_version`; removing or renaming a code is a major bump.
 
-### Example (partial)
+### Example — `ok`
+
+Zero-key Attempt 1 (`site_text_trafilatura`) populates `pages`; the other
+slots are reserved for providers that register later (see
+`docs/SPEC.md` — shipped-vs-deferred).
+
+```json
+{
+  "schema_version": "0.2.0",
+  "status": "ok",
+  "data": {
+    "site": "acme-bakery.com",
+    "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "pages": {
+      "homepage_text": "Acme Bakery is a bakery in Portland, OR. ...",
+      "about_text": "Acme Bakery has served Portland, OR since 2010. ...",
+      "services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
+      "tech_stack": ["WordPress", "Elementor"]
+    },
+    "reviews": null,
+    "social": null,
+    "signals": null,
+    "mentions": null
+  },
+  "provenance": {
+    "site_text_trafilatura": {
+      "status": "ok",
+      "latency_ms": 412,
+      "error": null,
+      "provider_version": "0.1.0",
+      "cost_incurred": 0
+    }
+  },
+  "error": null
+}
+```
+
+### Example — `partial` (zero-key blocked, smart-proxy unset)
 
 ```json
 {
   "schema_version": "0.2.0",
   "status": "partial",
-  "data": { "site": "example.com", "fetched_at": "...", "pages": null, ... },
-  "provenance": { "site_text_trafilatura": { "status": "failed", ... } },
+  "data": {
+    "site": "walled-garden.example",
+    "fetched_at": "2026-04-22T18:35:14.928144Z",
+    "pages": null,
+    "reviews": null,
+    "social": null,
+    "signals": null,
+    "mentions": null
+  },
+  "provenance": {
+    "site_text_trafilatura": {
+      "status": "failed",
+      "latency_ms": 842,
+      "error": "blocked_by_antibot (HTTP 403)",
+      "provider_version": "0.1.0",
+      "cost_incurred": 0
+    },
+    "smart_proxy_http": {
+      "status": "not_configured",
+      "latency_ms": 0,
+      "error": "missing env var: COMPANYCTX_SMART_PROXY_URL — export COMPANYCTX_SMART_PROXY_URL='http://user:pass@host:port' to wire your residential-proxy vendor",
+      "provider_version": "0.1.0",
+      "cost_incurred": 0
+    }
+  },
   "error": {
     "code": "blocked_by_antibot",
     "message": "blocked_by_antibot (HTTP 403)",
@@ -95,9 +155,14 @@ class CompanyContext(BaseModel):
     signals: HeuristicSignals | None = None
 ```
 
-Nothing else goes at the top level in v0.1. People-data fields (contact,
+Nothing else goes at the top level. People-data fields (contact,
 decision-maker, enrichment) are out of scope — that enrichment belongs
 upstream (Apollo / Clearbit / manual research).
+
+In v0.2, only `pages` populates on a live zero-key or smart-proxy run.
+`reviews` / `social` / `signals` / `mentions` stay `null` until their
+providers register (see `docs/SPEC.md` for the deferred-provider table
+and tracking issues).
 
 ## Sub-models
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -67,34 +67,37 @@ Zero-key Attempt 1 (`site_text_trafilatura`) populates `pages`; the other
 slots are reserved for providers that register later (see
 `docs/SPEC.md` — shipped-vs-deferred).
 
+Keys are shown in the alphabetical order the CLI emits
+(`json.dumps(..., sort_keys=True)`) so the block is copy-paste reproducible.
+
 ```json
 {
-  "schema_version": "0.2.0",
-  "status": "ok",
   "data": {
-    "site": "acme-bakery.com",
     "fetched_at": "2026-04-22T18:35:02.767112Z",
+    "mentions": null,
     "pages": {
-      "homepage_text": "Acme Bakery is a bakery in Portland, OR. ...",
       "about_text": "Acme Bakery has served Portland, OR since 2010. ...",
+      "homepage_text": "Acme Bakery is a bakery in Portland, OR. ...",
       "services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
       "tech_stack": ["WordPress", "Elementor"]
     },
     "reviews": null,
-    "social": null,
     "signals": null,
-    "mentions": null
+    "site": "acme-bakery.com",
+    "social": null
   },
+  "error": null,
   "provenance": {
     "site_text_trafilatura": {
-      "status": "ok",
-      "latency_ms": 412,
+      "cost_incurred": 0,
       "error": null,
+      "latency_ms": 412,
       "provider_version": "0.1.0",
-      "cost_incurred": 0
+      "status": "ok"
     }
   },
-  "error": null
+  "schema_version": "0.2.0",
+  "status": "ok"
 }
 ```
 
@@ -102,38 +105,38 @@ slots are reserved for providers that register later (see
 
 ```json
 {
-  "schema_version": "0.2.0",
-  "status": "partial",
   "data": {
-    "site": "walled-garden.example",
     "fetched_at": "2026-04-22T18:35:14.928144Z",
+    "mentions": null,
     "pages": null,
     "reviews": null,
-    "social": null,
     "signals": null,
-    "mentions": null
-  },
-  "provenance": {
-    "site_text_trafilatura": {
-      "status": "failed",
-      "latency_ms": 842,
-      "error": "blocked_by_antibot (HTTP 403)",
-      "provider_version": "0.1.0",
-      "cost_incurred": 0
-    },
-    "smart_proxy_http": {
-      "status": "not_configured",
-      "latency_ms": 0,
-      "error": "missing env var: COMPANYCTX_SMART_PROXY_URL — export COMPANYCTX_SMART_PROXY_URL='http://user:pass@host:port' to wire your residential-proxy vendor",
-      "provider_version": "0.1.0",
-      "cost_incurred": 0
-    }
+    "site": "walled-garden.example",
+    "social": null
   },
   "error": {
     "code": "blocked_by_antibot",
     "message": "blocked_by_antibot (HTTP 403)",
     "suggestion": "configure a smart-proxy provider key or skip this prospect"
-  }
+  },
+  "provenance": {
+    "site_text_trafilatura": {
+      "cost_incurred": 0,
+      "error": "blocked_by_antibot (HTTP 403)",
+      "latency_ms": 842,
+      "provider_version": "0.1.0",
+      "status": "failed"
+    },
+    "smart_proxy_http": {
+      "cost_incurred": 0,
+      "error": "missing env var: COMPANYCTX_SMART_PROXY_URL — export COMPANYCTX_SMART_PROXY_URL='http://user:pass@host:port' to wire your residential-proxy vendor",
+      "latency_ms": 0,
+      "provider_version": "0.1.0",
+      "status": "not_configured"
+    }
+  },
+  "schema_version": "0.2.0",
+  "status": "partial"
 }
 ```
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -43,7 +43,7 @@ don't build on a contract we don't honour yet:
 
 | Command / flag | Why reserved | Tracking |
 |---|---|---|
-| `companyctx batch <csv>` | Fan-out wrapper over `fetch`; lands with the cache so re-runs are cheap. | #38 (external) |
+| `companyctx batch <csv>` | Fan-out wrapper over `fetch`; lands alongside the cache so re-runs are cheap. | #9 |
 | `companyctx cache list` | Vertical Memory surface; needs the SQLite layer. | #9 |
 | `companyctx cache clear [--site X] [--older-than 7d]` | Same. | #9 |
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1,17 +1,18 @@
 # SNAPSHOT — canonical at `noontide-projects/boston-v1/decisions/`; do not maintain here
 
-> This file is a frozen snapshot taken at scaffolding time (Milestone 1).
-> The canonical spec lives in the upstream design workspace under the
-> `companyctx` spec-location/shape decision (schema + CLI shape) and the
-> `companyctx` scope-and-brand-lock decision (output contract, Deterministic
-> Waterfall, Vertical Memory, `status` enum).
+> This file is a snapshot of the CLI + envelope surface. The canonical spec
+> lives in the upstream design workspace under the `companyctx`
+> spec-location/shape decision (schema + CLI shape) and the `companyctx`
+> scope-and-brand-lock decision (output contract, Deterministic Waterfall,
+> Vertical Memory, `status` enum).
 >
-> Future spec edits land upstream and flow back via a new handoff cycle, not
-> via PRs against this file.
+> Shape edits land upstream and flow back via a new handoff cycle. Shipped-vs-
+> deferred state (which commands / flags / providers are wired today) is
+> refreshed with each release — this file is current as of `v0.2.0`.
 
 ---
 
-# companyctx — v0.1 spec
+# companyctx — spec (v0.2)
 
 ## Purpose
 
@@ -27,25 +28,44 @@ layer that consumes the JSON. No people data in v0.1 (company side only).
 
 Built with Typer. Conforms to clig.dev.
 
+Shipped in v0.2:
+
 | Command | Behavior |
 |---|---|
-| `companyctx fetch <site>` | Run all providers for one site; print or write result. |
+| `companyctx fetch <site>` | Run the Deterministic Waterfall for one site; emit one envelope. |
 | `companyctx schema` | Emit the envelope's Draft 2020-12 JSON Schema to stdout. |
-| `companyctx batch <csv>` | Run fetch over CSV of sites, write each result to a file. |
-| `companyctx validate <json>` | Validate a JSON payload against the pydantic schema. |
-| `companyctx cache list` | Inspect cache entries. |
-| `companyctx cache clear [--site X] [--older-than 7d]` | Prune the cache. |
-| `companyctx providers list` | Show available providers + their status + cost hint. |
+| `companyctx validate <path>` | Round-trip a JSON envelope through the Pydantic schema. |
+| `companyctx providers list [--json]` | Enumerate registered providers — slug, waterfall tier, category, cost hint, config status, reason. |
 
-Global flags on `fetch`:
+Reserved in the CLI surface but **not wired** in v0.2 — invoking them
+prints a tracking-issue pointer to stderr and exits non-zero, so agents
+don't build on a contract we don't honour yet:
 
-- `--out <path>`, `--json` / `--markdown`, `--verbose`
-- `--no-cache` — bypass the cache read path for this run.
-- `--refresh` — ignore cache, re-fetch every provider, write fresh back.
-- `--from-cache` — return only the cached payload, never hit the network;
-  exit non-zero on miss. (First-class Vertical-Memory flag.)
-- `--config <toml>`, `--mock` (loads from `fixtures/<site>/` instead of network).
+| Command / flag | Why reserved | Tracking |
+|---|---|---|
+| `companyctx batch <csv>` | Fan-out wrapper over `fetch`; lands with the cache so re-runs are cheap. | #38 (external) |
+| `companyctx cache list` | Vertical Memory surface; needs the SQLite layer. | #9 |
+| `companyctx cache clear [--site X] [--older-than 7d]` | Same. | #9 |
+
+Flags on `fetch`:
+
+- `--out <path>` — write JSON to a file instead of stdout.
+- `--json` / `--markdown` — `--json` is the supported contract.
+  `--markdown` is **experimental and not implemented** in v0.2; the CLI
+  rejects it with an explicit message so downstream pipelines don't ship a
+  silent contract (#68).
+- `--mock` — load from `fixtures/<site>/` instead of the network. Paired
+  with `--fixtures-dir` (default `./fixtures`).
+- `--verbose` — per-provider run-log to stderr.
 - `--ignore-robots` — explicit CLI-only; **not** settable via TOML or env.
+
+Reserved but **not wired** — `fetch` rejects these with a `typer.BadParameter`
+pointing at #9 so pipelines can't silently rely on cache behavior:
+
+- `--no-cache`
+- `--refresh`
+- `--from-cache`
+- `--config <toml>`
 
 ## Output contract
 
@@ -81,6 +101,48 @@ Status semantics:
 blocked_by_antibot | path_traversal_rejected | response_too_large |
 no_provider_succeeded | misconfigured_provider`. See `docs/SCHEMA.md` for the
 shape.
+
+### `schema_version`
+
+Every envelope carries a top-level `schema_version: Literal["0.2.0"]`.
+Agents branch on shape by reading this field directly — no substring-
+parsing an error string. Adding an optional envelope field is a PATCH (no
+`schema_version` bump); adding or renaming an `EnvelopeError.code` is a
+MINOR bump; changing or removing an existing field is a MAJOR bump. v0.1
+envelopes lack the `schema_version` field and fail validation under
+`extra="forbid"`.
+
+### `providers list` output shape
+
+The text output is human-first; the JSON output is the agent contract.
+`--json` emits a list of dicts, one per registered provider:
+
+```json
+[
+  {
+    "slug": "site_text_trafilatura",
+    "tier": "zero-key",
+    "category": "site_text",
+    "cost_hint": "free",
+    "status": "ready",
+    "reason": null
+  },
+  {
+    "slug": "smart_proxy_http",
+    "tier": "smart-proxy",
+    "category": "smart_proxy",
+    "cost_hint": "per-call",
+    "status": "not_configured",
+    "reason": "missing env: COMPANYCTX_SMART_PROXY_URL"
+  }
+]
+```
+
+`tier ∈ {"zero-key", "smart-proxy", "direct-api"}` reflects the Attempt
+band in the waterfall. `status ∈ {"ready", "not_configured"}` is computed
+at list-time from each provider's declared `required_env`; agents should
+treat `not_configured` as "the provider will not run until the reason is
+addressed."
 
 ## Data model (pydantic v2)
 
@@ -133,6 +195,12 @@ Missing providers degrade — never raise — and surface their reason via
 `provenance[slug].status`. The top-level envelope's `status` aggregates these
 into a single pipeline-branchable value.
 
+In v0.2 the only Attempt-1 provider registered is `site_text_trafilatura`,
+so live + `--mock` runs populate `data.pages.*` and leave `data.reviews` /
+`data.social` / `data.signals` / `data.mentions` as `null`. Those slots
+fill in as the direct-API and site-heuristic providers listed above
+register. The envelope shape does not change.
+
 ## Provider-plugin interface
 
 Each deterministic call class is a pluggable provider, discovered via Python
@@ -170,41 +238,55 @@ Providers sit on the **Deterministic Waterfall** (see `docs/ARCHITECTURE.md`):
 Every attempt maps to the same `CompanyContext` shape. Pipelines never branch
 on which attempt succeeded — they branch on the envelope's `status`.
 
-### Day-one providers (committed for v0.1)
+### Providers shipped in v0.2
 
-- **Site text:** `trafilatura` (primary) + `readability-lxml` (fallback) —
-  bus-factor mitigation, both wired day-one.
-- **Site metadata:** `extruct` — JSON-LD, microdata, OpenGraph, RDFa,
-  schema.org `Organization` + `LocalBusiness` + `sameAs` social handle
-  discovery.
-- **Reviews:** Google Places via `googlemaps`; Yelp Fusion via `yelpapi`.
-  Env-gated; missing key → `status: "not_configured"`.
-- **Social discovery:** BeautifulSoup + regex against platform URL shapes
-  + extruct `sameAs`.
-- **Social counts:** YouTube via `google-api-python-client` `channels.list`
-  (ToS-safe). IG / FB / TikTok follower counts stay nullable in v0.1.
-- **Signals:** site-heuristic provider — `copyright_year`,
-  `last_blog_post_at`, `team_size_claim` (regex), tech-stack detection
-  (WordPress / Shopify / Webflow / Wix / Squarespace / custom).
-- **Mentions:** Brave Search stub — plumbing only, returns
-  `status: "not_configured"` so `providers list` surfaces a clear TODO.
+- **`site_text_trafilatura`** (Attempt 1, zero-key). Stealth fetch via
+  `curl_cffi` pinned to `impersonate="chrome146"` + `trafilatura`
+  extraction + tech-stack fingerprint (WordPress / Shopify / Webflow / Wix
+  / Squarespace / Elementor / WooCommerce). Populates `data.pages.*`.
+  Graceful-partial on 401 / 403 / timeout.
+- **`smart_proxy_http`** (Attempt 2, user-keyed, vendor-agnostic). URL-
+  style HTTP proxy: user embeds credentials in
+  `COMPANYCTX_SMART_PROXY_URL`; unset → `status: "not_configured"` with an
+  actionable suggestion. On success the recovered bytes flow through the
+  same shared extractor and populate `data.pages.*`. The named-vendor
+  adapter lands after the smart-proxy vendor eval spike (#63).
 
-## Cache (Vertical Memory)
+### Providers deferred
 
-SQLite fetch cache under XDG-compliant paths. Opt-in via `--cache` flag or
-TOML; disabled by default in v0.1.
+- **`site_text_readability`** — bus-factor fallback for Attempt 1; wires
+  alongside the fallback-selection logic in a future milestone.
+- **`site_meta_extruct`** — JSON-LD / microdata / OpenGraph / RDFa /
+  `sameAs` social-handle discovery.
+- **`reviews_google_places`** (direct-API) — Google Places via
+  `googlemaps`. Tracking: #7.
+- **`reviews_yelp_fusion`** (direct-API) — Yelp Fusion via `yelpapi`.
+- **`social_discovery_site`** (zero-key) — BeautifulSoup + regex +
+  extruct `sameAs`.
+- **`social_counts_youtube`** (direct-API) — YouTube Data via
+  `google-api-python-client` `channels.list` (ToS-safe). IG / FB / TikTok
+  follower counts stay nullable per-provider policy.
+- **`signals_site_heuristic`** (zero-key) — `copyright_year`,
+  `last_blog_post_at`, `team_size_claim`.
+- **`mentions_brave_stub`** (direct-API) — press / awards / podcast
+  discovery. Tracking: #58.
 
-- Key: `(normalized_host, provider_set_hash, provider_slug)` + TTL per
-  provider.
-- Payload: the full normalized `CompanyContext` payload + `provenance`
-  (not raw HTML snippets).
-- Schema is versioned alongside the Pydantic model; migrations are
-  first-class.
-- `companyctx --refresh` forces re-fetch; `companyctx --from-cache` is the
-  cache-only mode.
+Until a direct-API provider registers, `data.reviews` / `data.social` /
+`data.mentions` / `data.signals` stay `null` on live runs and in
+`--mock` fixture output. The envelope shape is stable regardless.
 
-The cache is designed to compound into a queryable local B2B dataset over
-normal use. A `companyctx query ...` DSL is v0.2 scope, not v0.1.
+## Cache (Vertical Memory) — reserved, not wired in v0.2
+
+The SQLite fetch cache is a **design invariant** but not implemented in
+v0.2. The CLI surface reserves `--refresh` / `--from-cache` / `--no-cache`
+/ `--config` and rejects them with a `typer.BadParameter` until #9 lands.
+Tracked shape when wired:
+
+- Storage: SQLite under XDG-compliant paths (`platformdirs`).
+- Key: `(normalized_host, provider_set_hash, provider_slug)` + per-provider TTL.
+- Payload: the full normalized `CompanyContext` + `provenance` (not raw HTML).
+- Schema is versioned alongside the Pydantic model; migrations are first-class.
+- A `companyctx query ...` DSL over the cache is future scope, not v0.2.
 
 ## Observability
 

--- a/examples/01-basic-fetch.sh
+++ b/examples/01-basic-fetch.sh
@@ -24,27 +24,37 @@ else
   companyctx fetch "$SITE" --mock --json
 fi
 
-# --- EXPECTED OUTPUT (abbreviated, v0.2 envelope) ---
+# --- EXPECTED OUTPUT (v0.2 envelope, keys sorted by the CLI) ---
 # {
-#   "schema_version": "0.2.0",
-#   "status": "ok",
 #   "data": {
-#     "site": "acme-bakery",
-#     "fetched_at": "2026-04-21T14:44:59.314842Z",
+#     "fetched_at": "2026-04-22T18:44:05.810816Z",
+#     "mentions": null,
 #     "pages": {
-#       "homepage_text": "Acme Bakery is a bakery in Portland, OR. ...",
 #       "about_text": "Acme Bakery has served Portland, OR since 2010. ...",
+#       "homepage_text": "Acme Bakery is a bakery in Portland, OR. ...",
 #       "services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
 #       "tech_stack": ["WordPress", "Elementor"]
 #     },
-#     "reviews": { "count": 142, "rating": 4.6, "source": "reviews_google_places" },
-#     "social": { "handles": { "instagram": "@acmebakery" }, "follower_counts": {} },
-#     "signals": { "copyright_year": 2024, "team_size_claim": "team of 3" },
-#     "mentions": null
+#     "reviews": null,
+#     "signals": null,
+#     "site": "acme-bakery",
+#     "social": null
 #   },
+#   "error": null,
 #   "provenance": {
-#     "site_text_trafilatura":  { "status": "ok", "latency_ms": 0,   "error": null, "provider_version": "0.1.0" },
-#     "reviews_google_places":  { "status": "ok", "latency_ms": 312, "error": null, "provider_version": "0.1.0" }
+#     "site_text_trafilatura": {
+#       "cost_incurred": 0,
+#       "error": null,
+#       "latency_ms": 0,
+#       "provider_version": "0.1.0",
+#       "status": "ok"
+#     }
 #   },
-#   "error": null
+#   "schema_version": "0.2.0",
+#   "status": "ok"
 # }
+#
+# Note: v0.2 ships one Attempt-1 provider (site_text_trafilatura), so
+# `data.reviews` / `data.social` / `data.signals` / `data.mentions` are
+# reserved in the schema but return null. Direct-API providers that
+# populate those slots are on the roadmap — see docs/SPEC.md.

--- a/examples/02-jq-filtering.sh
+++ b/examples/02-jq-filtering.sh
@@ -45,7 +45,7 @@ case "$STATUS" in
   degraded) echo "❌ primary fetch blocked — see .error.code / .error.suggestion" ;;
 esac
 
-# --- EXPECTED OUTPUT ---
+# --- EXPECTED OUTPUT (v0.2 — pages populated, other slots null) ---
 # === Just the services and tech stack ===
 # {
 #   "site": "acme-bakery",
@@ -54,10 +54,16 @@ esac
 # }
 #
 # === Social handles as a flat list ===
-# instagram: @acmebakery
+# (empty — data.social is null until a social-discovery provider ships)
 #
 # === Review summary, or a fallback string if unavailable ===
-# 4.6★ across 142 reviews (reviews_google_places)
+# no review data for this provider set
 #
 # === Branch on status — the pipeline contract ===
 # ✅ complete envelope — safe to synthesize
+#
+# Note: v0.2 ships the zero-key Attempt 1 only. The review / social
+# branches above are the exact fallbacks your pipeline should rely on —
+# they kick in whenever a slot's provider isn't configured or hasn't
+# been written yet. The jq pipe is identical under live runs once the
+# direct-API providers register; no pipeline rewrite needed.

--- a/examples/03-brains-and-muscles.sh
+++ b/examples/03-brains-and-muscles.sh
@@ -38,13 +38,18 @@ company. The payload is your only source of truth about the prospect.
 Read the JSON. Pay special attention to:
   - data.pages.services       (what they sell)
   - data.pages.tech_stack     (how they operate)
-  - data.reviews              (market reputation)
-  - data.signals              (copyright year, team size, cadence)
+  - data.pages.homepage_text  (their positioning)
+  - data.reviews              (market reputation — null in v0.2 until a
+                               direct-API provider is configured)
+  - data.signals              (copyright year, team size, cadence — null
+                               in v0.2 until the site-heuristic provider
+                               ships)
 
 Write a 3-sentence cold email pitching our generic AI-automation
 services. Reference exactly one specific piece of their tech stack or
 one specific service they offer to prove you did your research. Do
-not invent facts that aren't in the payload. Output only the email
+not invent facts that aren't in the payload (including: if a field is
+null, treat it as unknown, not as 'no reviews'). Output only the email
 body — no subject line, no sign-off.
 "
 

--- a/examples/04-sales-meeting-prep.sh
+++ b/examples/04-sales-meeting-prep.sh
@@ -83,7 +83,7 @@ echo "💡 Rep tip: mention one specific item above in the first"
 echo "   90 seconds of the call to prove you did your homework."
 echo "======================================================"
 
-# --- EXPECTED OUTPUT ---
+# --- EXPECTED OUTPUT (v0.2 — pages populated, other slots null) ---
 # ======================================================
 #   SALES CHEAT SHEET — acme-bakery
 # ======================================================
@@ -94,17 +94,21 @@ echo "======================================================"
 #     tech stack: WordPress, Elementor
 #
 # 👥 TEAM + CADENCE
-#     team:           team of 3
-#     copyright:      2024
-#     last blog post: 2026-01-01T00:00:00
+#     team:           not stated
+#     copyright:      not stated
+#     last blog post: not stated
 #
 # ⭐ MARKET REPUTATION
-#     4.6★ across 142 reviews (source: reviews_google_places)
-#
-# 🔗 SOCIAL
-#     instagram: @acmebakery
+#     no review data available
 #
 # ======================================================
 # 💡 Rep tip: mention one specific item above in the first
 #    90 seconds of the call to prove you did your homework.
 # ======================================================
+#
+# Note: "not stated" and "no review data available" reflect v0.2
+# reality — data.signals / data.reviews / data.social stay null until
+# the site-heuristic and direct-API providers register. The jq
+# fallbacks in this script (// "not stated", // "n/a") are the exact
+# shape a production pipeline should use; they start filling in as
+# each provider ships without any script change.

--- a/examples/05-pe-rollup-screener.sh
+++ b/examples/05-pe-rollup-screener.sh
@@ -17,6 +17,15 @@
 #
 # Tune the thresholds for your thesis; the shape is what matters.
 #
+# NOTE for v0.2: this thesis reads `data.reviews` and `data.signals`,
+# which are null in v0.2 until the direct-API and site-heuristic
+# providers register (see docs/SPEC.md — reviews_google_places is
+# tracked under #7). Against the shipped zero-key provider the
+# screener will return 0 candidates today. The shape is deliberately
+# preserved — once a review provider is configured (export
+# GOOGLE_PLACES_API_KEY and drop --mock), the same filter starts
+# producing hits without any change to this script.
+#
 # Requires: jq
 # Usage:    ./05-pe-rollup-screener.sh          # uses embedded demo list
 #           ./05-pe-rollup-screener.sh my-list.txt
@@ -81,14 +90,20 @@ echo "Done. $HITS candidate(s) matched the thesis."
 echo "Next: hand the hits to a human analyst for diligence, or pipe into"
 echo "      a brief-generation step (see 03-brains-and-muscles.sh)."
 
-# --- EXPECTED OUTPUT (illustrative — numbers vary per fixture) ---
+# --- EXPECTED OUTPUT (v0.2, --mock) ---
 # 🔍 Screening for rollup candidates
 #    thesis: rating ≥ 4.5, ≥ 75 reviews, WordPress, copyright ≤ 2023
 # --------------------------------------------------------------------
-# ✅ acme-bakery         | 4.6★ × 142 reviews | stack: WordPress,Elementor | copyright 2023
-# ✅ cornerstone-bakery  | 4.7★ ×  96 reviews | stack: WordPress,WooCommerce | copyright 2022
-# ✅ hilltop-contractor  | 4.8★ × 210 reviews | stack: WordPress           | copyright 2021
 # --------------------------------------------------------------------
-# Done. 3 candidate(s) matched the thesis.
+# Done. 0 candidate(s) matched the thesis.
 # Next: hand the hits to a human analyst for diligence, or pipe into
 #       a brief-generation step (see 03-brains-and-muscles.sh).
+#
+# Reason: the thesis filters on data.reviews.* and data.signals.*,
+# which are null in v0.2 (see header note). Once a review provider is
+# registered + configured the filter starts producing hits against
+# the fixture corpus:
+#
+# ✅ acme-bakery         | 4.6★ × 142 reviews | stack: WordPress,Elementor | copyright 2023
+# ✅ cornerstone-bakery  | 4.7★ ×  96 reviews | stack: WordPress,WooCommerce | copyright 2022
+# ✅ hilltop-contractor  | 4.8★ × 210 reviews | stack: WordPress            | copyright 2021

--- a/examples/06-competitor-monitor.py
+++ b/examples/06-competitor-monitor.py
@@ -116,10 +116,12 @@ def main() -> None:
     state_path = Path.cwd() / f".competitor-state-{args.site.replace('/', '_')}.json"
 
     print(f"🕵️  Monitoring {args.site}...")
-    # When --mock is on, the fixtures tree is alongside the package's canonical
-    # `fixtures/` dir; in real use (without --mock) the CLI / library hits the
-    # network via the zero-key stealth fetcher.
-    fixtures_dir = Path("fixtures") if args.mock else None
+    # `fixtures/` lives at the repo root alongside `examples/`. We resolve it
+    # relative to this script so the recipe runs from anywhere (including
+    # `cd examples && python 06-...`). In real use (no --mock), the library
+    # hits the network via the zero-key stealth fetcher and fixtures_dir is
+    # None.
+    fixtures_dir = (Path(__file__).resolve().parent.parent / "fixtures") if args.mock else None
     envelope = run(args.site, mock=args.mock, fixtures_dir=fixtures_dir)
 
     if envelope.status != "ok":
@@ -155,15 +157,25 @@ if __name__ == "__main__":
     main()
 
 
-# --- EXPECTED OUTPUT (first run) ---
-# 🕵️  Monitoring rival-startup.com...
-# 📌 baseline saved to .competitor-state-rival-startup.com.json.
-# Re-run tomorrow to see the first diff.
+# --- EXPECTED OUTPUT (first run against fixture corpus, --mock) ---
+# 🕵️  Monitoring acme-bakery...
+# 📌 baseline saved to .competitor-state-acme-bakery.json. Re-run tomorrow to see the first diff.
 #
-# --- EXPECTED OUTPUT (subsequent run, after a competitor actually changed) ---
+# --- EXPECTED OUTPUT (subsequent run, no change) ---
+# 🕵️  Monitoring acme-bakery...
+# ✅ no meaningful changes since last run.
+# 💾 baseline refreshed (2026-04-22T18:46:24.247102+00:00)
+#
+# --- EXPECTED OUTPUT (illustrative — live run against a competitor that actually changed) ---
 # 🕵️  Monitoring rival-startup.com...
-# 🚨 3 change(s) detected on rival-startup.com:
+# 🚨 2 change(s) detected on rival-startup.com:
 #    🆕 services added: ['AI consulting']
 #    🛠  tech added: ['Next.js', 'Datadog']
-#    📈 review count +18 (now 160)
 # 💾 baseline refreshed (2026-04-22T09:15:02.184210+00:00)
+#
+# Note: review-count diffs, copyright-year diffs, and social-handle
+# diffs rely on data.reviews / data.signals / data.social — all null
+# in v0.2 until the direct-API and site-heuristic providers register.
+# Until then, the script diffs pages.services + pages.tech_stack only;
+# the other branches are no-ops that wake up automatically once a
+# provider fills the relevant slot.

--- a/examples/07-inbound-webhook-enrichment/README.md
+++ b/examples/07-inbound-webhook-enrichment/README.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-An inbound lead submits only an email (`josh@acme-logistics.example.test`) via
+An inbound lead submits only an email (`josh@acme-bakery.example.test`) via
 a demo-request form. The RevOps team needs the company's services,
 tech stack, review footprint, and rough size on the CRM record
 *before* the first sales reply. Standing options:
@@ -23,6 +23,13 @@ only part that differs per integration).
 **What you save:** the enrichment-vendor line item.
 **What you get:** a deterministic, schema-locked JSON envelope you
 can version and diff, rather than a vendor's opaque result set.
+
+In v0.2 the CRM payload fills in `primary_services` +
+`tech_stack_detected` from the shipped zero-key provider; `review_*`,
+`social_handles`, `team_size_claim`, and `copyright_year` arrive null
+until the direct-API and site-heuristic providers register (see
+[`../../docs/SPEC.md`](../../docs/SPEC.md)). The payload shape is
+stable; nothing downstream changes when those slots start filling in.
 
 ## How to run it
 

--- a/examples/07-inbound-webhook-enrichment/main.py
+++ b/examples/07-inbound-webhook-enrichment/main.py
@@ -49,7 +49,10 @@ def handle_inbound_lead(event: dict[str, Any], *, mock: bool = False) -> dict[st
     if domain in FREE_EMAIL_DOMAINS:
         return {"status": "ignored", "reason": "free email provider"}
 
-    fixtures_dir = Path("fixtures") if mock else None
+    # Resolve fixtures/ relative to this script so the recipe runs from any
+    # CWD (including `cd examples/07-inbound-webhook-enrichment && python
+    # main.py`). In real use (no --mock) fixtures_dir stays None.
+    fixtures_dir = (Path(__file__).resolve().parent.parent.parent / "fixtures") if mock else None
     envelope = run(domain, mock=mock, fixtures_dir=fixtures_dir)
 
     if envelope.status != "ok":
@@ -111,20 +114,28 @@ if __name__ == "__main__":
     main()
 
 
-# --- EXPECTED OUTPUT (demo event with --mock) ---
+# --- EXPECTED OUTPUT (v0.2, demo event with --mock) ---
 # {
 #   "crm_payload": {
 #     "company_domain": "acme-bakery",
-#     "context_fetched_at": "2026-04-21T14:44:59.314842Z",
-#     "copyright_year": 2024,
+#     "context_fetched_at": "2026-04-22T18:46:29.655450+00:00",
+#     "copyright_year": null,
 #     "primary_services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
-#     "review_count": 142,
-#     "review_rating": 4.6,
-#     "review_source": "reviews_google_places",
-#     "social_handles": {"instagram": "@acmebakery"},
-#     "team_size_claim": "team of 3",
+#     "review_count": null,
+#     "review_rating": null,
+#     "review_source": null,
+#     "social_handles": {},
+#     "team_size_claim": null,
 #     "tech_stack_detected": ["WordPress", "Elementor"]
 #   },
 #   "domain": "acme-bakery",
 #   "status": "enriched"
 # }
+#
+# Note: primary_services + tech_stack_detected come from the shipped
+# zero-key provider. review_* / social_handles / team_size_claim /
+# copyright_year are null in v0.2 because the direct-API and
+# site-heuristic providers that populate them aren't registered yet
+# (see docs/SPEC.md — Google Places is tracked under #7). The CRM
+# payload's field map is deliberately stable; when a provider ships,
+# the null fields start filling in without any code change.

--- a/examples/08-support-ticket-context.py
+++ b/examples/08-support-ticket-context.py
@@ -46,7 +46,9 @@ def generate_support_context(
         }
 
     domain = customer_email.split("@", 1)[1]
-    fixtures_dir = Path("fixtures") if mock else None
+    # Resolve fixtures/ relative to this script so the recipe runs from
+    # anywhere (including `cd examples && python 08-...`).
+    fixtures_dir = (Path(__file__).resolve().parent.parent / "fixtures") if mock else None
     envelope = run(domain, mock=mock, fixtures_dir=fixtures_dir)
 
     if envelope.status != "ok":
@@ -129,14 +131,12 @@ if __name__ == "__main__":
     main()
 
 
-# --- EXPECTED OUTPUT (demo ticket, --mock) ---
+# --- EXPECTED OUTPUT (v0.2, demo ticket, --mock) ---
 # ### Internal note (paste into Zendesk / Intercom / Freshdesk):
 # --- AUTOMATED CUSTOMER CONTEXT ---
 # Domain:           acme-bakery
 # What they sell:   Custom cakes, Catering, Wholesale bread, Pastry boxes
 # Their tech stack: WordPress, Elementor
-# Team size claim:  team of 3
-# Social:           instagram: @acmebakery
 # Ticket excerpt:   Our online orders stopped syncing to the kitchen printer yesterday. ...
 # Suggested action: tailor the reply to their tech stack; avoid generic boilerplate.
 # ----------------------------------
@@ -145,7 +145,12 @@ if __name__ == "__main__":
 # {
 #   "customer_domain": "acme-bakery",
 #   "customer_services": ["Custom cakes", "Catering", "Wholesale bread", "Pastry boxes"],
-#   "customer_social_handles": {"instagram": "@acmebakery"},
-#   "customer_team_size_claim": "team of 3",
+#   "customer_social_handles": {},
+#   "customer_team_size_claim": null,
 #   "customer_tech_stack": ["WordPress", "Elementor"]
 # }
+#
+# Note: "Team size claim" / "Social:" don't appear in the note when
+# data.signals / data.social are null (v0.2 default). Once a
+# site-heuristic / social-discovery provider registers, those lines
+# appear automatically — no script change.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,20 @@ companyctx fetch <domain> --json
 CRM payload, diff-and-alert, agent-prompt injection. The muscle is
 always the same; the orchestration around it is what changes.
 
+### What to expect on v0.2
+
+v0.2 ships the zero-key Attempt 1 (`site_text_trafilatura`) and the
+user-keyed smart-proxy Attempt 2 (`smart_proxy_http`). That means live
+and `--mock` runs populate `data.pages.*` and leave
+`data.reviews` / `data.social` / `data.signals` / `data.mentions` as
+`null` until the direct-API and site-heuristic providers register
+(roadmap — see [`../docs/SPEC.md`](../docs/SPEC.md)). Every recipe in
+this gallery is coded against the stable envelope shape with
+fallbacks for the null slots; nothing breaks when a provider
+registers, it just starts populating the field. A recipe's "expected
+output" block flags which lines are v0.2 reality vs. what will start
+appearing once direct-API providers ship.
+
 ## How this folder is built
 
 1. **Zero to hero.** Files are numbered. Start at `01`, work up. Each

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,23 @@ This folder is a curated, zero-to-hero progression. Each file is a
 self-contained recipe that solves a real business problem using
 `companyctx`'s schema-locked JSON envelope.
 
+## Prerequisites
+
+Install `companyctx` first — **every recipe in this gallery assumes the
+CLI and package are on the Python path**:
+
+```bash
+# From a clean checkout, either:
+pipx install companyctx            # CLI on PATH; enough for bash recipes
+# or, for the .py recipes that `from companyctx.core import run`:
+pip install -e ".[dev,extract,reviews,youtube]"
+```
+
+Without one of those, the `.sh` scripts fail at the first `companyctx`
+invocation and the `.py` scripts fail at import.
+
+## The primitive
+
 Every example assumes the same primitive:
 
 ```bash

--- a/examples/partner-integration.md
+++ b/examples/partner-integration.md
@@ -79,23 +79,28 @@ deterministic version of the same thing.
   shows `reviews` went from populated to null, `provenance.reviews_*`
   tells you whether the direct-API provider lost its key, hit a
   quota, or wasn't configured.
-- **Cache is built in.** The second run against the same domain
-  (within the TTL window) hits SQLite and skips the network
-  entirely. No rate-limit worries in a 100-domain batch.
+- **Local SQLite cache (design invariant, deferred).** The Vertical
+  Memory layer — a local SQLite cache that compounds into a queryable
+  B2B dataset — is the post-v0.2 direction. Not wired today: v0.2
+  rejects `--from-cache` / `--refresh` / `--no-cache` / `--config`
+  with a pointer to the tracking issue (#9). For rate-limit control
+  today, do your own domain-level throttling outside the pipe.
 
 ## The zero-key default
 
 The default fetch path is zero-key — no API credentials required for
-the homepage-derived fields (`data.pages.*`) or the heuristic signals
-(`data.signals.copyright_year`, `.last_blog_post_at`, etc.). The
-pipeline can run the muscle against an entire batch without any
-credentials setup.
+the homepage-derived fields (`data.pages.*`). The pipeline can run
+the muscle against an entire batch without any credentials setup.
 
-For `data.reviews`, `data.social.follower_counts`, and the media
-mentions fields, configure the direct-API providers your ICP needs
-(Google Places for local-biz reviews, YouTube Data API for social
-counts, Brave Search API for press mentions). See
-[`../docs/PROVIDERS.md`](../docs/PROVIDERS.md).
+`data.reviews`, `data.social`, `data.signals`, and `data.mentions` are
+reserved in the schema but null in v0.2 — the providers that populate
+them (Google Places for local-biz reviews, the site-heuristic provider
+for signals, YouTube Data for social counts, Brave Search for mentions)
+are roadmap work (tracked under #7 / #58 and a future milestone).
+See [`../docs/PROVIDERS.md`](../docs/PROVIDERS.md) and
+[`../docs/SPEC.md`](../docs/SPEC.md) for the full shipped-vs-deferred
+table. Pipeline code should already be tolerant of these null slots —
+the schema contract does not change when providers register later.
 
 ## Graceful-partial — handling antibot blocks
 
@@ -119,19 +124,22 @@ This is the whole point of the envelope — your pipeline branches on
 
 ## Batch pattern
 
-For a 100-domain batch:
+For a 100-domain batch today, drive `fetch` from your own loop:
 
 ```bash
-# Fan out the muscle. --refresh bypasses the cache for a fresh run;
-# drop it on subsequent passes to reuse cached payloads.
+mkdir -p out
 while IFS= read -r domain; do
-  companyctx fetch "$domain" --json --refresh > "out/${domain}.json"
+  companyctx fetch "$domain" --json > "out/${domain}.json"
 done < prospects-batch.csv
 
 # Then in your Python pipeline, iterate the envelopes.
 ```
 
-Or, when it lands, `companyctx batch prospects-batch.csv --out-dir out/`.
+`companyctx batch <csv>` is reserved in the CLI surface but **not
+wired** in v0.2 — it exits non-zero with a tracking-issue pointer so
+you don't build on a contract we don't honour. When it lands
+alongside the SQLite cache (#9), this wrapper becomes
+`companyctx batch prospects-batch.csv --out out/`.
 
 ## Related recipes in this gallery
 

--- a/tests/test_schema_verb.py
+++ b/tests/test_schema_verb.py
@@ -98,7 +98,7 @@ def test_fetch_rejects_silent_cache_flag(flag: str) -> None:
     assert result.exit_code != 0
     plain = _plain(result.output)
     assert flag in plain
-    assert "not implemented" in plain or "issues/37" in plain
+    assert "not implemented" in plain or "issues/9" in plain
 
 
 def test_fetch_rejects_silent_config_flag(tmp_path: Path) -> None:
@@ -121,7 +121,7 @@ def test_fetch_rejects_silent_config_flag(tmp_path: Path) -> None:
     assert result.exit_code != 0
     plain = _plain(result.output)
     assert "--config" in plain
-    assert "not implemented" in plain or "issues/37" in plain
+    assert "not implemented" in plain or "issues/9" in plain
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smart_proxy_http.py
+++ b/tests/test_smart_proxy_http.py
@@ -448,13 +448,40 @@ def test_waterfall_handles_non_bytes_smart_proxy_body(tmp_path: Path) -> None:
     assert "non-bytes body" in env.provenance["proxy_returns_string"].error
 
 
-def test_cli_providers_list_shows_smart_proxy_http() -> None:
+def test_cli_providers_list_shows_smart_proxy_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env-unset path: smart_proxy_http surfaces as ``not_configured`` in the text table."""
+    monkeypatch.delenv(ENV_URL, raising=False)
+
     runner = CliRunner()
     result = runner.invoke(app, ["providers", "list"])
     assert result.exit_code == 0, result.stdout
     assert "smart_proxy_http" in result.stdout
-    assert "smart_proxy" in result.stdout
+    assert "smart-proxy" in result.stdout
     assert "per-call" in result.stdout
+    assert "not_configured" in result.stdout
+    assert f"missing env: {ENV_URL}" in result.stdout
+
+
+def test_cli_providers_list_json_shape_tracks_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``providers list --json`` flips smart_proxy_http's status when the env var is set."""
+    runner = CliRunner()
+
+    monkeypatch.delenv(ENV_URL, raising=False)
+    unset = runner.invoke(app, ["providers", "list", "--json"])
+    assert unset.exit_code == 0, unset.stdout
+    payload = json.loads(unset.stdout)
+    proxy_row = next(row for row in payload if row["slug"] == "smart_proxy_http")
+    assert proxy_row["tier"] == "smart-proxy"
+    assert proxy_row["status"] == "not_configured"
+    assert proxy_row["reason"] == f"missing env: {ENV_URL}"
+
+    monkeypatch.setenv(ENV_URL, "http://user:pass@host:8080")
+    ready = runner.invoke(app, ["providers", "list", "--json"])
+    assert ready.exit_code == 0, ready.stdout
+    ready_payload = json.loads(ready.stdout)
+    ready_row = next(row for row in ready_payload if row["slug"] == "smart_proxy_http")
+    assert ready_row["status"] == "ready"
+    assert ready_row["reason"] is None
 
 
 def test_cli_fetch_blocked_fixture_partial_without_env(


### PR DESCRIPTION
## Summary

- Public docs (README hero + status + provider tables, `docs/SPEC.md`, `docs/SCHEMA.md`, `SKILL.md`, every file in `examples/`) now describe the surface that actually shipped in `v0.2.0` — zero-key `site_text_trafilatura` + user-keyed `smart_proxy_http`, structured `EnvelopeError`, top-level `schema_version`. Aspirational `reviews.*` / `social.*` / `signals.*` fragments are gone; deferred features (SQLite cache, `batch`, direct-API providers, `--markdown`, `--refresh`/`--from-cache`) are explicitly labelled with tracking issues (`#9`, `#7`, `#58`, `#68`).
- `companyctx providers list --json` (and the text table) now carries waterfall tier, config status (`ready` / `not_configured`), and a reason column. Providers opt in via an optional `required_env` class var; `smart_proxy_http` declares `COMPANYCTX_SMART_PROXY_URL` so the env-unset path surfaces the wiring gap before the first fetch.
- `fetch --markdown` help text labels the flag experimental (runtime already rejects it).
- Every CLI stub / rejected-flag message now points at `#9` (the real cache tracking issue) instead of phantom `#37` / `#38` — swept across cli.py, `docs/SPEC.md`, `CHANGELOG.md`, and the `test_schema_verb` assertions.
- Example recipes resolve `fixtures/` relative to the script so they run clean from any CWD; `examples/README.md` opens with an explicit install prereq.

## Commits

- `c556d6b` — feat(cli): enrich `providers list` with tier, config status, --json (#68 Part B)
- `042eae8` — docs: honesty pass — README hero + SPEC/SCHEMA/SKILL match shipped v0.2 surface
- `c7b8375` — docs(examples): refresh gallery against shipped v0.2 CLI output
- `93265c4` — fix(cli): point cache/batch/config rejections at real tracking issue #9
- `a3e590c` — fix: sweep remaining #37 drift + document examples install prerequisite

## Acceptance (from #67)

- [x] README hero renders an envelope a user can reproduce on current-main `v0.2.0`.
- [x] Every envelope example in the repo is current-real OR explicitly labeled aspirational with a target version + tracking issue.
- [x] Every `SPEC.md` claim matches shipped v0.2 CLI behavior.
- [x] `SCHEMA.md` describes the v0.2 envelope (`EnvelopeError` + `schema_version`).
- [x] `SKILL.md` matches `companyctx schema` output.
- [x] All `examples/` bash/python files run clean against `v0.2.0` (smoke-tested locally against `.venv/bin/companyctx 0.2.0`).
- [x] `providers list` CLI enriched; help text + SPEC + SKILL updated.
- [x] `--markdown` labeled experimental in help.
- [x] CI green — pending remote run.
- [x] Closes #68 entirely (Part A shipped with v0.2.0; Part B lands here).

Closes #67
Closes #68

## Test plan

- [x] `ruff format --check .` — 40 files already formatted
- [x] `ruff check .` — all checks passed
- [x] `mypy companyctx tests` — 33 source files, no issues
- [x] `pytest -q` — 233 tests passed
- [x] Every bash + Python recipe in `examples/` smoke-tested locally against `v0.2.0`; all exit 0.
- [x] `companyctx fetch acme-bakery --mock --no-cache` verified to print the (real) `issues/9` URL.