### PR TITLE
feat(schema)!: add empty_response error code + bump schema_version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — envelope schema bump (v0.3)
+
+- **`schema_version` bumped to `"0.3.0"`.** Adding the `empty_response`
+  code to the closed `EnvelopeError.code` Literal is a minor schema
+  bump. v0.2.0 envelopes still validate under the old Literal but the
+  orchestrator now emits `"0.3.0"` on every run.
+- **New `empty_response` error code (COX-44 / #79).** Zero-key
+  `site_text_trafilatura` now checks the extracted homepage text
+  against `EMPTY_RESPONSE_BYTES = 64`; below that, the provider
+  surfaces `status: "failed"`, `error: "empty_response"`, and the
+  orchestrator lands `error.code: "empty_response"` at the envelope
+  top level with an actionable suggestion. Retires the
+  "empty-body silent-success" disclosure added to v0.2.0 Known
+  Limitations. Automatic smart-proxy retry on empty is intentionally
+  out of scope — the recovery path skips `empty_response` rows.
+
 ### Added
 
 - **`companyctx providers list --json`** — registry introspection as a JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code to the closed `EnvelopeError.code` Literal is a minor schema
   bump. v0.2.0 envelopes still validate under the old Literal but the
   orchestrator now emits `"0.3.0"` on every run.
-- **New `empty_response` error code (COX-44 / #79).** Zero-key
-  `site_text_trafilatura` now checks the extracted homepage text
-  against `EMPTY_RESPONSE_BYTES = 64`; below that, the provider
-  surfaces `status: "failed"`, `error: "empty_response"`, and the
-  orchestrator lands `error.code: "empty_response"` at the envelope
-  top level with an actionable suggestion. Retires the
-  "empty-body silent-success" disclosure added to v0.2.0 Known
-  Limitations. Automatic smart-proxy retry on empty is intentionally
-  out of scope — the recovery path skips `empty_response` rows.
+- **New `empty_response` error code (COX-44 / #79).** Both waterfall
+  attempts now gate on extracted-text UTF-8 byte length against
+  `EMPTY_RESPONSE_BYTES = 64`. Zero-key `site_text_trafilatura`
+  (Attempt 1) and the smart-proxy recovery path (Attempt 2) share the
+  gate via `companyctx.extract.is_empty_response`, so a proxy that
+  returns an HTTP 200 with an empty body surfaces as
+  `status: "failed"`, `error: "empty_response"` on its provenance row
+  instead of laundering a silent-success onto the envelope. Measuring
+  UTF-8 bytes (not `len(text)`) keeps multibyte scripts from
+  false-positiving as empty. The orchestrator lands
+  `error.code: "empty_response"` at the envelope top level with an
+  actionable suggestion. Retires the "empty-body silent-success"
+  disclosure added to v0.2.0 Known Limitations. Automatic smart-proxy
+  retry on an Attempt-1 empty is intentionally out of scope — the
+  recovery path skips primary rows tagged `empty_response`.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ companyctx fetch acme-bakery.com --json
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }
 ```
@@ -168,7 +168,7 @@ On full block with no Attempt-2/3 providers configured:
     "suggestion": "configure a smart-proxy provider key or skip this prospect"
   },
   "provenance": { "site_text_trafilatura": { "cost_incurred": 0, "error": "blocked_by_antibot (HTTP 403)", "latency_ms": 842, "provider_version": "0.1.0", "status": "failed" } },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "partial"
 }
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -15,11 +15,11 @@ schema-locked JSON envelope out. Zero keys on the default path.
 
 - Companies only. Never extract people data.
 - Branch on `status` (`ok | partial | degraded`), not on try/except.
-- Every envelope carries `schema_version`. v0.2 is `"0.2.0"`.
+- Every envelope carries `schema_version`. v0.3 is `"0.3.0"`.
 - When `status != "ok"`, `error` is a structured `{code, message, suggestion}`;
   switch on `error.code` (one of `ssrf_rejected | network_timeout |
   blocked_by_antibot | path_traversal_rejected | response_too_large |
-  no_provider_succeeded | misconfigured_provider`).
+  no_provider_succeeded | misconfigured_provider | empty_response`).
 - Pipe stdout; don't parse logs. The JSON envelope is the contract.
 - The `data.site` field is the identifier; `data.pages` holds homepage-
   derived content (`homepage_text`, `about_text`, `services`, `tech_stack`).
@@ -56,7 +56,7 @@ schema-locked JSON envelope out. Zero keys on the default path.
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }
 ```

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -18,7 +18,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from companyctx import __version__
-from companyctx.extract import site_signals_from_homepage_bytes
+from companyctx.extract import (
+    EMPTY_RESPONSE_ERROR as _EMPTY_RESPONSE_ERROR,
+)
+from companyctx.extract import (
+    is_empty_response,
+    site_signals_from_homepage_bytes,
+)
 from companyctx.providers import discover
 from companyctx.providers.base import FetchContext, ProviderBase
 from companyctx.schema import (
@@ -63,8 +69,9 @@ _ROBOTS_BLOCK_ERROR = "blocked_by_robots"
 # check (COX-44). Automatic proxy-retry on empty is explicitly out of
 # scope — agents branching on ``error.code`` decide what to do. Skipping
 # the retry here keeps the provider's honest signal from being laundered
-# into a degraded-but-ok row by the waterfall.
-_EMPTY_RESPONSE_ERROR = "empty_response"
+# into a degraded-but-ok row by the waterfall. The error-string constant
+# itself lives in ``companyctx.extract`` so the provider, the orchestrator,
+# and the smart-proxy recovery path all reference one source of truth.
 EMPTY_RESPONSE_SUGGESTION = (
     "site returned HTTP 200 with effectively no content; "
     "try --ignore-robots or check with a browser"
@@ -230,10 +237,16 @@ def _attempt_smart_proxy_recovery(
 ) -> SiteSignals | None:
     """Try every registered smart-proxy provider in slug order.
 
-    The first one that returns bytes + ``ok`` metadata wins. Every attempt's
-    metadata is written into ``provenance`` so the user sees the trace. On
-    bytes the shared extractor turns them into a ``SiteSignals`` payload;
-    parse failures downgrade the proxy row to ``failed`` and move on.
+    The first one that returns bytes + ``ok`` metadata AND clears the
+    empty-response gate wins. Every attempt's metadata is written into
+    ``provenance`` so the user sees the trace. On bytes the shared
+    extractor turns them into a ``SiteSignals`` payload; parse failures
+    downgrade the proxy row to ``failed`` and move on. An effectively-
+    empty recovery body (extracted text below
+    :data:`EMPTY_RESPONSE_BYTES`) is tagged ``failed`` with
+    ``error="empty_response"`` so the Attempt-2 path cannot launder a
+    silent-success onto the envelope — parallel to the Attempt-1 gate
+    in ``site_text_trafilatura``.
     """
     for proxy_slug in sorted(smart_proxy_registry):
         proxy_cls = smart_proxy_registry[proxy_slug]
@@ -242,13 +255,22 @@ def _attempt_smart_proxy_recovery(
         if body is None or proxy_meta.status != "ok":
             continue
         try:
-            return site_signals_from_homepage_bytes(body)
+            recovered = site_signals_from_homepage_bytes(body)
         except Exception as exc:  # noqa: BLE001 - deliberate boundary
             provenance[proxy_slug] = _failed_metadata(
                 error=f"smart-proxy bytes extraction failed: {exc.__class__.__name__}: {exc}",
                 provider_version=proxy_meta.provider_version,
                 latency_ms=proxy_meta.latency_ms,
             )
+            continue
+        if is_empty_response(recovered.homepage_text):
+            provenance[proxy_slug] = _failed_metadata(
+                error=_EMPTY_RESPONSE_ERROR,
+                provider_version=proxy_meta.provider_version,
+                latency_ms=proxy_meta.latency_ms,
+            )
+            continue
+        return recovered
     return None
 
 

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -59,6 +59,16 @@ _SMART_PROXY_CATEGORY = "smart_proxy"
 # The smart-proxy must not "recover" these — the user opted into robots
 # compliance by not passing ``--ignore-robots``.
 _ROBOTS_BLOCK_ERROR = "blocked_by_robots"
+# ``empty_response`` is the "HTTP 200 with effectively no body" honesty
+# check (COX-44). Automatic proxy-retry on empty is explicitly out of
+# scope — agents branching on ``error.code`` decide what to do. Skipping
+# the retry here keeps the provider's honest signal from being laundered
+# into a degraded-but-ok row by the waterfall.
+_EMPTY_RESPONSE_ERROR = "empty_response"
+EMPTY_RESPONSE_SUGGESTION = (
+    "site returned HTTP 200 with effectively no content; "
+    "try --ignore-robots or check with a browser"
+)
 
 
 def run(
@@ -142,6 +152,8 @@ def run(
                 if meta.status != "failed":
                     continue
                 if meta.error == _ROBOTS_BLOCK_ERROR:
+                    continue
+                if meta.error == _EMPTY_RESPONSE_ERROR:
                     continue
                 recovered_signals = _attempt_smart_proxy_recovery(
                     site=site,
@@ -397,7 +409,20 @@ def _build_envelope_error(
         "one or more providers failed" if status == "partial" else "no providers succeeded"
     )
     code = _classify_error_code(message, failure_status, status)
-    return EnvelopeError(code=code, message=message, suggestion=GENERIC_SUGGESTION)
+    return EnvelopeError(code=code, message=message, suggestion=_suggestion_for(code))
+
+
+def _suggestion_for(code: EnvelopeErrorCode) -> str:
+    """Per-code actionable suggestion.
+
+    Most codes share the generic "configure a smart-proxy or skip" fix.
+    ``empty_response`` gets its own line because smart-proxy retry is not
+    the right remediation — the fetch already worked, the site returned
+    nothing.
+    """
+    if code == "empty_response":
+        return EMPTY_RESPONSE_SUGGESTION
+    return GENERIC_SUGGESTION
 
 
 def _classify_error_code(
@@ -428,6 +453,8 @@ def _classify_error_code(
         return "network_timeout"
     if "blocked_by_antibot" in lower or "blocked_by_robots" in lower:
         return "blocked_by_antibot"
+    if "empty_response" in lower:
+        return "empty_response"
     # 401/403 without the canonical `blocked_by_antibot` prefix still read as
     # an access block; other 4xx/5xx codes fall through to the generic
     # no-provider-succeeded catch.
@@ -505,7 +532,7 @@ def _fallback_envelope(
         error = EnvelopeError(
             code="no_provider_succeeded",
             message="no providers succeeded",
-            suggestion=GENERIC_SUGGESTION,
+            suggestion=_suggestion_for("no_provider_succeeded"),
         )
     return Envelope(
         status=status,

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -408,25 +408,35 @@ def _build_envelope_error(
     status: EnvelopeStatus,
     provenance: Mapping[str, ProviderRunMetadata],
 ) -> EnvelopeError | None:
-    """Map the first failing provenance row to a structured :class:`EnvelopeError`.
+    """Map the terminal failing provenance row to a structured :class:`EnvelopeError`.
 
-    Returns ``None`` when ``status == "ok"``. Otherwise picks the first
-    provider row with a non-``ok`` status and a populated error string,
-    classifies the string into one of the closed set of codes
-    (:data:`EnvelopeErrorCode`), and pairs it with a generic-but-actionable
-    suggestion. Callers should treat this as the orchestrator's one source of
-    truth for the top-level error — per-provider rows still carry their own
-    raw error strings in :attr:`ProviderRunMetadata.error`.
+    Returns ``None`` when ``status == "ok"``. Otherwise classifies one
+    provider row's error into the closed :data:`EnvelopeErrorCode` set and
+    pairs it with an actionable suggestion. Callers should treat this as
+    the orchestrator's one source of truth for the top-level error —
+    per-provider rows still carry their own raw error strings in
+    :attr:`ProviderRunMetadata.error`.
+
+    Selection rule: prefer ``empty_response`` when any row carries it
+    (COX-44 terminal signal — a proxy returning an empty body after an
+    ``blocked_by_antibot`` Attempt 1 means the terminal waterfall outcome
+    is "the site had nothing," not "blocked by antibot"). Otherwise fall
+    back to the first failing row in provenance order, which is the
+    Attempt-1 failure for runs without a smart-proxy.
     """
     if status == "ok":
         return None
-    failure_reason = None
-    failure_status: ProviderStatus | None = None
-    for meta in provenance.values():
-        if meta.status in ("failed", "not_configured", "degraded") and meta.error:
-            failure_reason = meta.error
-            failure_status = meta.status
-            break
+    failures = [
+        (meta.status, meta.error)
+        for meta in provenance.values()
+        if meta.status in ("failed", "not_configured", "degraded") and meta.error
+    ]
+    chosen = next(
+        (row for row in failures if row[1] == _EMPTY_RESPONSE_ERROR),
+        failures[0] if failures else None,
+    )
+    failure_status: ProviderStatus | None = chosen[0] if chosen else None
+    failure_reason: str | None = chosen[1] if chosen else None
     message = failure_reason or (
         "one or more providers failed" if status == "partial" else "no providers succeeded"
     )

--- a/companyctx/extract.py
+++ b/companyctx/extract.py
@@ -15,6 +15,29 @@ from bs4 import BeautifulSoup
 
 from companyctx.schema import SiteSignals
 
+# Empty-response honesty threshold (COX-44). The measure is UTF-8 byte
+# length, not ``len(text)`` — a 40-character CJK or accented homepage
+# that extracts to ~120 UTF-8 bytes should NOT be misclassified as
+# effectively empty. A legitimate one-page brochure site clears 64
+# bytes easily; below that the fetch worked but the site returned
+# nothing useful (blank body, login-wall stub, JS-only landing with no
+# SSR content). Both the zero-key provider and the smart-proxy recovery
+# path consult this gate so Attempt 1 and Attempt 2 enforce the same
+# contract.
+EMPTY_RESPONSE_BYTES = 64
+EMPTY_RESPONSE_ERROR = "empty_response"
+
+
+def is_empty_response(homepage_text: str) -> bool:
+    """Return True when the extracted text is below the empty-response cutoff.
+
+    Measures UTF-8 byte length so multibyte scripts don't false-positive
+    as empty. Called after extraction, not on raw response bytes — the
+    gate is about "was there anything useful to say" after trafilatura /
+    BS4 stripped chrome.
+    """
+    return len(homepage_text.encode("utf-8")) < EMPTY_RESPONSE_BYTES
+
 
 def extract_body_text(html: str) -> str:
     """Return the main-body text of one HTML document.
@@ -94,8 +117,11 @@ def site_signals_from_homepage_bytes(body: bytes) -> SiteSignals:
 
 
 __all__ = [
+    "EMPTY_RESPONSE_BYTES",
+    "EMPTY_RESPONSE_ERROR",
     "detect_tech_stack",
     "extract_body_text",
     "extract_services",
+    "is_empty_response",
     "site_signals_from_homepage_bytes",
 ]

--- a/companyctx/providers/site_text_trafilatura.py
+++ b/companyctx/providers/site_text_trafilatura.py
@@ -27,7 +27,13 @@ from urllib.parse import urljoin, urlparse
 
 from curl_cffi import requests
 
-from companyctx.extract import detect_tech_stack, extract_body_text, extract_services
+from companyctx.extract import (
+    EMPTY_RESPONSE_ERROR,
+    detect_tech_stack,
+    extract_body_text,
+    extract_services,
+    is_empty_response,
+)
 from companyctx.providers.base import FetchContext
 from companyctx.robots import is_allowed
 from companyctx.schema import ProviderRunMetadata, SiteSignals
@@ -46,15 +52,9 @@ _VERSION = "0.1.0"
 # research/2026-04-21-tls-impersonation-spike.md.
 _IMPERSONATE: Literal["chrome146"] = "chrome146"
 _SAFE_FIXTURE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
-# Extracted-text-length cutoff for the ``empty_response`` honesty check.
-# Tighter than FM-7's 1024-byte "thin extract" cutoff in
-# ``docs/RISK-REGISTER.md`` — a legitimate one-page brochure site still
-# clears 64 characters of visible text. Below this, the fetch worked but
-# the site returned effectively nothing (HTTP 200 with an empty body or a
-# login-wall stub); silent-success there violates the "loud failure >
-# silent fallthrough" contract. Surface it as a structured failure.
-EMPTY_RESPONSE_BYTES = 64
-EMPTY_RESPONSE_ERROR = "empty_response"
+# The empty-response cutoff + gate live in ``companyctx.extract`` so the
+# zero-key provider and the smart-proxy recovery path share one source
+# of truth (see COX-44).
 
 
 class Provider:
@@ -89,7 +89,7 @@ class Provider:
         # Surface it as a structured failure so downstream agents branch on
         # ``error.code == "empty_response"`` instead of seeing ``status: ok``
         # with a zero-length homepage.
-        if len(signals.homepage_text) < EMPTY_RESPONSE_BYTES:
+        if is_empty_response(signals.homepage_text):
             return None, _failed(EMPTY_RESPONSE_ERROR, start, self.version, mock=ctx.mock)
 
         # Mock mode has no real network latency; zero it so --mock runs are

--- a/companyctx/providers/site_text_trafilatura.py
+++ b/companyctx/providers/site_text_trafilatura.py
@@ -46,6 +46,15 @@ _VERSION = "0.1.0"
 # research/2026-04-21-tls-impersonation-spike.md.
 _IMPERSONATE: Literal["chrome146"] = "chrome146"
 _SAFE_FIXTURE_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# Extracted-text-length cutoff for the ``empty_response`` honesty check.
+# Tighter than FM-7's 1024-byte "thin extract" cutoff in
+# ``docs/RISK-REGISTER.md`` — a legitimate one-page brochure site still
+# clears 64 characters of visible text. Below this, the fetch worked but
+# the site returned effectively nothing (HTTP 200 with an empty body or a
+# login-wall stub); silent-success there violates the "loud failure >
+# silent fallthrough" contract. Surface it as a structured failure.
+EMPTY_RESPONSE_BYTES = 64
+EMPTY_RESPONSE_ERROR = "empty_response"
 
 
 class Provider:
@@ -74,6 +83,14 @@ class Provider:
             return None, _failed(str(exc), start, self.version, mock=ctx.mock)
         except Exception as exc:  # pragma: no cover — defensive boundary
             return None, _failed(f"unexpected: {exc!r}", start, self.version, mock=ctx.mock)
+
+        # Empty-response honesty check (COX-44): a successful fetch that
+        # yields effectively no extracted text is silent-success, not ok.
+        # Surface it as a structured failure so downstream agents branch on
+        # ``error.code == "empty_response"`` instead of seeing ``status: ok``
+        # with a zero-length homepage.
+        if len(signals.homepage_text) < EMPTY_RESPONSE_BYTES:
+            return None, _failed(EMPTY_RESPONSE_ERROR, start, self.version, mock=ctx.mock)
 
         # Mock mode has no real network latency; zero it so --mock runs are
         # byte-identical across invocations (the determinism contract).

--- a/companyctx/schema.py
+++ b/companyctx/schema.py
@@ -5,14 +5,11 @@ Every model sets ``extra="forbid"`` so schema drift is loud. See
 ``docs/SCHEMA.md`` for the contract walkthrough and ``docs/SPEC.md`` for the
 frozen spec snapshot.
 
-v0.2.0 is a schema-breaking release for the envelope:
-
-* New top-level ``schema_version: Literal["0.2.0"]`` lets consumers branch on
-  the envelope shape rather than substring-parsing error strings.
-* ``error`` changes from ``str | None`` to a structured :class:`EnvelopeError`
-  with machine-readable ``code`` + human-readable ``message`` + optional
-  ``suggestion``. The former top-level ``suggestion`` field moves into the
-  error model.
+v0.2.0 introduced the schema-locked envelope (top-level ``schema_version``
+plus structured :class:`EnvelopeError`). v0.3.0 adds one new error code —
+``empty_response`` — so agents can branch on "site returned HTTP 200 with
+effectively no content" instead of mistaking a silent-success for ok data.
+Per the closed-set rule, a new code is a minor schema bump.
 """
 
 from __future__ import annotations
@@ -22,7 +19,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-SCHEMA_VERSION = "0.2.0"
+SCHEMA_VERSION = "0.3.0"
 
 EnvelopeStatus = Literal["ok", "partial", "degraded"]
 ProviderStatus = Literal["ok", "degraded", "failed", "not_configured"]
@@ -35,6 +32,7 @@ EnvelopeErrorCode = Literal[
     "response_too_large",
     "no_provider_succeeded",
     "misconfigured_provider",
+    "empty_response",
 ]
 
 
@@ -158,7 +156,7 @@ class Envelope(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.2.0"] = "0.2.0"
+    schema_version: Literal["0.3.0"] = "0.3.0"
     status: EnvelopeStatus
     data: CompanyContext
     provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -3,10 +3,14 @@
 The Pydantic v2 shape `companyctx` emits. The schema is the product — providers
 are replaceable, the contract is not.
 
-The envelope below is the v0.2.0 shape. Adding a new optional field is
+The envelope below is the v0.3.0 shape. Adding a new optional field is
 backwards-compatible; removing or renaming a field — or changing the shape of
 an existing one — is a schema-version bump. Always branch on the top-level
 `schema_version` field to detect envelope evolution.
+
+v0.3.0 adds the `empty_response` error code to the closed `EnvelopeError.code`
+Literal — a minor bump from v0.2.0. See `docs/SPEC.md` §empty_response for
+the threshold and semantics.
 
 Consumers can pull the live JSON Schema with:
 
@@ -20,7 +24,7 @@ Every `companyctx fetch` invocation returns one wrapper around the payload:
 
 ```python
 class Envelope(BaseModel):
-    schema_version: Literal["0.2.0"] = "0.2.0"
+    schema_version: Literal["0.3.0"] = "0.3.0"
     status: Literal["ok", "partial", "degraded"]
     data: CompanyContext
     provenance: dict[str, ProviderRunMetadata]
@@ -51,6 +55,7 @@ class EnvelopeError(BaseModel):
         "response_too_large",
         "no_provider_succeeded",
         "misconfigured_provider",
+        "empty_response",
     ]
     message: str                     # human-readable — logs / UI
     suggestion: str | None = None    # actionable next step
@@ -96,7 +101,7 @@ Keys are shown in the alphabetical order the CLI emits
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }
 ```
@@ -135,7 +140,7 @@ Keys are shown in the alphabetical order the CLI emits
       "status": "not_configured"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "partial"
 }
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -107,12 +107,11 @@ no_provider_succeeded | misconfigured_provider | empty_response`. See
 Closes the silent-success-on-empty gap called out in v0.2.0 Known
 Limitations. When the zero-key `site_text` provider completes a fetch but
 the extracted homepage text is shorter than `EMPTY_RESPONSE_BYTES = 64`
-characters (tunable in `companyctx/providers/site_text_trafilatura.py`),
-the provider row surfaces as `status: "failed"`, `error:
-"empty_response"`. The orchestrator maps that to top-level
-`error.code: "empty_response"` with an actionable suggestion
-(`"site returned HTTP 200 with effectively no content; try
---ignore-robots or check with a browser"`).
+UTF-8 bytes (tunable in `companyctx/extract.py`), the provider row
+surfaces as `status: "failed"`, `error: "empty_response"`. The
+orchestrator maps that to top-level `error.code: "empty_response"` with
+an actionable suggestion (`"site returned HTTP 200 with effectively no
+content; try --ignore-robots or check with a browser"`).
 
 The 64-byte cutoff is stricter than FM-7's 1024-byte "thin extract"
 threshold in `docs/RISK-REGISTER.md`. FM-7 describes legitimate

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -118,11 +118,24 @@ The 64-byte cutoff is stricter than FM-7's 1024-byte "thin extract"
 threshold in `docs/RISK-REGISTER.md`. FM-7 describes legitimate
 one-page / brochureware sites that extract to thin-but-real content —
 those stay `status: ok` with a short `homepage_text`. `empty_response`
-is the 0-to-64-byte case where the fetch worked but the site returned
-nothing useful (blank body, login-wall stub, JS-only landing with no
-SSR content). Automatic proxy retry on empty is intentionally out of
-scope: the smart-proxy recovery path skips rows tagged
-`empty_response`. Agents decide whether to retry upstream.
+is the 0-to-64-byte UTF-8-byte case where the fetch worked but the
+site returned nothing useful (blank body, login-wall stub, JS-only
+landing with no SSR content). The gate measures **UTF-8 bytes**, not
+character count, so multibyte scripts (CJK, accented Latin, Cyrillic)
+don't false-positive as empty.
+
+The gate applies to **both waterfall attempts**: Attempt 1
+(`site_text_trafilatura`) and Attempt 2 (smart-proxy recovery) run the
+same check against the extracted homepage text. An effectively-empty
+recovery body surfaces on the proxy row as
+`status: "failed"`, `error: "empty_response"` so Attempt 2 can't launder
+a silent-success onto the envelope.
+
+Automatic proxy retry on an Attempt-1 `empty_response` failure is
+intentionally out of scope: the smart-proxy recovery path skips
+primary rows tagged `empty_response` (the zero-key fetch already
+worked — the site returned nothing, retrying through a proxy won't
+invent content). Agents decide whether to retry upstream.
 
 ### `schema_version`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,7 +8,7 @@
 >
 > Shape edits land upstream and flow back via a new handoff cycle. Shipped-vs-
 > deferred state (which commands / flags / providers are wired today) is
-> refreshed with each release — this file is current as of `v0.2.0`.
+> refreshed with each release — this file is current as of `v0.3.0`.
 
 ---
 
@@ -76,7 +76,7 @@ around a crash.
 
 ```
 {
-  "schema_version": "0.2.0",       // top-level shape discriminator
+  "schema_version": "0.3.0",       // top-level shape discriminator
   "status": "ok" | "partial" | "degraded",
   "data":   CompanyContext,        // the schema payload (always present, may
                                    //   have nullable fields on partial)
@@ -99,18 +99,41 @@ Status semantics:
 
 `EnvelopeError.code` is one of `ssrf_rejected | network_timeout |
 blocked_by_antibot | path_traversal_rejected | response_too_large |
-no_provider_succeeded | misconfigured_provider`. See `docs/SCHEMA.md` for the
-shape.
+no_provider_succeeded | misconfigured_provider | empty_response`. See
+`docs/SCHEMA.md` for the shape.
+
+#### `empty_response` (v0.3)
+
+Closes the silent-success-on-empty gap called out in v0.2.0 Known
+Limitations. When the zero-key `site_text` provider completes a fetch but
+the extracted homepage text is shorter than `EMPTY_RESPONSE_BYTES = 64`
+characters (tunable in `companyctx/providers/site_text_trafilatura.py`),
+the provider row surfaces as `status: "failed"`, `error:
+"empty_response"`. The orchestrator maps that to top-level
+`error.code: "empty_response"` with an actionable suggestion
+(`"site returned HTTP 200 with effectively no content; try
+--ignore-robots or check with a browser"`).
+
+The 64-byte cutoff is stricter than FM-7's 1024-byte "thin extract"
+threshold in `docs/RISK-REGISTER.md`. FM-7 describes legitimate
+one-page / brochureware sites that extract to thin-but-real content —
+those stay `status: ok` with a short `homepage_text`. `empty_response`
+is the 0-to-64-byte case where the fetch worked but the site returned
+nothing useful (blank body, login-wall stub, JS-only landing with no
+SSR content). Automatic proxy retry on empty is intentionally out of
+scope: the smart-proxy recovery path skips rows tagged
+`empty_response`. Agents decide whether to retry upstream.
 
 ### `schema_version`
 
-Every envelope carries a top-level `schema_version: Literal["0.2.0"]`.
+Every envelope carries a top-level `schema_version: Literal["0.3.0"]`.
 Agents branch on shape by reading this field directly — no substring-
 parsing an error string. Adding an optional envelope field is a PATCH (no
 `schema_version` bump); adding or renaming an `EnvelopeError.code` is a
-MINOR bump; changing or removing an existing field is a MAJOR bump. v0.1
-envelopes lack the `schema_version` field and fail validation under
-`extra="forbid"`.
+MINOR bump; changing or removing an existing field is a MAJOR bump.
+v0.3.0 adds the `empty_response` code to the closed set — a minor bump
+from v0.2.0. v0.1 envelopes lack the `schema_version` field and fail
+validation under `extra="forbid"`.
 
 ### `providers list` output shape
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -131,6 +131,14 @@ recovery body surfaces on the proxy row as
 `status: "failed"`, `error: "empty_response"` so Attempt 2 can't launder
 a silent-success onto the envelope.
 
+When both attempts fail (e.g. Attempt 1 `blocked_by_antibot` →
+Attempt 2 `empty_response`), `error.code` at the envelope level
+reflects the **terminal** waterfall outcome, not the trigger. An
+`empty_response` on any row wins the top-level code: the antibot
+block was the reason to retry; the empty proxy body is what the
+pipeline actually ended on. Per-provider rows still carry their own
+error strings in `provenance[slug].error` for full traceability.
+
 Automatic proxy retry on an Attempt-1 `empty_response` failure is
 intentionally out of scope: the smart-proxy recovery path skips
 primary rows tagged `empty_response` (the zero-key fetch already

--- a/docs/ZERO-KEY.md
+++ b/docs/ZERO-KEY.md
@@ -60,7 +60,7 @@ When zero-key can't fully succeed, `companyctx` does not crash, does not
 
 ```json
 {
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "partial",
   "data": {
     "site": "example.com",

--- a/examples/01-basic-fetch.sh
+++ b/examples/01-basic-fetch.sh
@@ -50,7 +50,7 @@ fi
 #       "status": "ok"
 #     }
 #   },
-#   "schema_version": "0.2.0",
+#   "schema_version": "0.3.0",
 #   "status": "ok"
 # }
 #

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -79,26 +79,30 @@ Five is the smallest set that touches every stack branch *and* the
 empty-`tech_stack` branch, so a regression in any of them breaks at
 least one regression case.
 
-### Failure-shape regressions — the durability two
+### Failure-shape regressions — the durability two + COX-44
 
 The 2026-04-21 100-site durability run against @joel-req's external seed list
 (see `durability-report-2026-04-21.md`) surfaced two HTML-capturable
-**FM-7** shapes (thin/empty content after successful fetch, per
-`docs/RISK-REGISTER.md` §FM-7) that sit outside the synthetic-corpus
-taxonomy:
+shapes where the fetch returns HTTP 200 with effectively no body:
 
 | Slug                       | Failure mode             | What it guards against                                                 |
 | -------------------------- | ------------------------ | ---------------------------------------------------------------------- |
 | `fm7-js-redirect-root`     | JS redirect to subpath   | Extractor hallucinating content from an empty `<head>`-only response.  |
 | `fm7-maintenance-page`     | "Temporarily unavailable"| Extractor inventing text when the body carries only a maintenance notice. |
+| `empty-response`           | 0-byte body, COX-44 pin  | Silent-success slipping back in if the `empty_response` provider gate regresses. |
 
-Both envelope outputs are `status: ok` with thin-or-empty
-`homepage_text` — the correct shape when a fetch succeeds but the
-response has little to extract. These fixtures carry only
-`homepage.html` + `expected.json` (no about/services/provider JSON), so
-they bypass the 30-synthetic-dirs invariant; the test suite filters
-them via `FAILURE_FIXTURE_SLUGS` in `tests/test_fixtures_corpus.py` and
-includes them in the byte-diff regression suite via
+Under v0.3 (COX-44 / #79), all three extract to fewer than
+`EMPTY_RESPONSE_BYTES` (64) characters and trip the provider's
+empty-response honesty check, so the envelope surfaces as
+`status: degraded`, `error.code: "empty_response"` instead of the
+v0.2 silent-success `status: ok` with zero-length `homepage_text`.
+Distinct from FM-7 in `docs/RISK-REGISTER.md`, which covers legitimate
+one-page brochure sites with thin-but-real content (≥ 64 chars) — those
+still return `status: ok`. These fixtures carry only `homepage.html` +
+`expected.json` (no about/services/provider JSON), so they bypass the
+30-synthetic-dirs invariant; the test suite filters them via
+`FAILURE_FIXTURE_SLUGS` in `tests/test_fixtures_corpus.py` and includes
+them in the byte-diff regression suite via
 `tests/test_regression_corpus.py`.
 
 ### Network-failure regressions — the `fixture-block.txt` sentinel

--- a/fixtures/acme-bakery/expected.json
+++ b/fixtures/acme-bakery/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/anchor-fitness/expected.json
+++ b/fixtures/anchor-fitness/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/apex-auto/expected.json
+++ b/fixtures/apex-auto/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/birmingham-iv-04/expected.json
+++ b/fixtures/birmingham-iv-04/expected.json
@@ -23,6 +23,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/bluepeak-agency/expected.json
+++ b/fixtures/bluepeak-agency/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/brightsmile-dental/expected.json
+++ b/fixtures/brightsmile-dental/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/brooklyn-loaves-bakery/expected.json
+++ b/fixtures/brooklyn-loaves-bakery/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/canopy-agency/expected.json
+++ b/fixtures/canopy-agency/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/cary-hormone-02/expected.json
+++ b/fixtures/cary-hormone-02/expected.json
@@ -23,6 +23,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/cedarpark-dental/expected.json
+++ b/fixtures/cedarpark-dental/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/charleston-medspa-05/expected.json
+++ b/fixtures/charleston-medspa-05/expected.json
@@ -26,6 +26,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/coastal-fitness/expected.json
+++ b/fixtures/coastal-fitness/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/cornerstone-bakery/expected.json
+++ b/fixtures/cornerstone-bakery/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/elmwood-dental/expected.json
+++ b/fixtures/elmwood-dental/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/empty-response/expected.json
+++ b/fixtures/empty-response/expected.json
@@ -5,7 +5,7 @@
     "pages": null,
     "reviews": null,
     "signals": null,
-    "site": "fm7-js-redirect-root.example",
+    "site": "empty-response.example",
     "social": null
   },
   "error": {

--- a/fixtures/empty-response/homepage.html
+++ b/fixtures/empty-response/homepage.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head></head><body></body></html>

--- a/fixtures/fm13-timeout-smb-01/expected.json
+++ b/fixtures/fm13-timeout-smb-01/expected.json
@@ -29,6 +29,6 @@
       "status": "not_configured"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "partial"
 }

--- a/fixtures/fm7-maintenance-page/expected.json
+++ b/fixtures/fm7-maintenance-page/expected.json
@@ -2,27 +2,26 @@
   "data": {
     "fetched_at": "2026-04-20T00:00:00Z",
     "mentions": null,
-    "pages": {
-      "about_text": null,
-      "homepage_text": "We'll be back soon.",
-      "services": [],
-      "tech_stack": []
-    },
+    "pages": null,
     "reviews": null,
     "signals": null,
     "site": "fm7-maintenance-page.example",
     "social": null
   },
-  "error": null,
+  "error": {
+    "code": "empty_response",
+    "message": "empty_response",
+    "suggestion": "site returned HTTP 200 with effectively no content; try --ignore-robots or check with a browser"
+  },
   "provenance": {
     "site_text_trafilatura": {
       "cost_incurred": 0,
-      "error": null,
+      "error": "empty_response",
       "latency_ms": 0,
       "provider_version": "0.1.0",
-      "status": "ok"
+      "status": "failed"
     }
   },
-  "schema_version": "0.2.0",
-  "status": "ok"
+  "schema_version": "0.3.0",
+  "status": "degraded"
 }

--- a/fixtures/forge-fitness/expected.json
+++ b/fixtures/forge-fitness/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/goldengate-auto/expected.json
+++ b/fixtures/goldengate-auto/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/greenfield-fitness/expected.json
+++ b/fixtures/greenfield-fitness/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/hilltop-contractor/expected.json
+++ b/fixtures/hilltop-contractor/expected.json
@@ -31,6 +31,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/hinsdale-derm-03/expected.json
+++ b/fixtures/hinsdale-derm-03/expected.json
@@ -37,6 +37,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/ironbell-fitness/expected.json
+++ b/fixtures/ironbell-fitness/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/ironworks-contractor/expected.json
+++ b/fixtures/ironworks-contractor/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/keystone-contractor/expected.json
+++ b/fixtures/keystone-contractor/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/mapleridge-contractor/expected.json
+++ b/fixtures/mapleridge-contractor/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/midtown-auto/expected.json
+++ b/fixtures/midtown-auto/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/northarlington-pharmacy-01/expected.json
+++ b/fixtures/northarlington-pharmacy-01/expected.json
@@ -23,6 +23,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/northlight-agency/expected.json
+++ b/fixtures/northlight-agency/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/northridge-dental/expected.json
+++ b/fixtures/northridge-dental/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/oakleaf-bakery/expected.json
+++ b/fixtures/oakleaf-bakery/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/pinewood-agency/expected.json
+++ b/fixtures/pinewood-agency/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/redwood-contractor/expected.json
+++ b/fixtures/redwood-contractor/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/riverstone-agency/expected.json
+++ b/fixtures/riverstone-agency/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/rustic-auto/expected.json
+++ b/fixtures/rustic-auto/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/seaside-dental/expected.json
+++ b/fixtures/seaside-dental/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/summit-auto/expected.json
+++ b/fixtures/summit-auto/expected.json
@@ -28,6 +28,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/fixtures/sunrise-bakery/expected.json
+++ b/fixtures/sunrise-bakery/expected.json
@@ -30,6 +30,6 @@
       "status": "ok"
     }
   },
-  "schema_version": "0.2.0",
+  "schema_version": "0.3.0",
   "status": "ok"
 }

--- a/tests/test_core_orchestrator.py
+++ b/tests/test_core_orchestrator.py
@@ -595,6 +595,90 @@ def test_empty_response_trips_honesty_check(
         assert env.data.pages.homepage_text
 
 
+def test_empty_response_applies_to_smart_proxy_recovery(tmp_path: Path) -> None:
+    """Attempt-2 must not launder silent-success past the honesty gate.
+
+    Primary zero-key provider fails with ``blocked_by_antibot`` — an error
+    that IS recoverable via smart-proxy per the waterfall. The proxy then
+    returns an HTTP 200 with an empty body. Before the fix this landed
+    ``status: "ok"`` with ``pages.homepage_text: ""``. After the fix the
+    recovery path treats the empty body as ``empty_response`` on the proxy
+    row, no recovery happens, and the envelope surfaces the honest shape.
+    """
+
+    class _BlockedPrimary:
+        slug: ClassVar[str] = "site_text_blocked"
+        category: ClassVar[Literal["site_text"]] = "site_text"
+        cost_hint: ClassVar[Literal["free"]] = "free"
+        version: ClassVar[str] = "0.1.0"
+
+        def fetch(
+            self, site: str, *, ctx: FetchContext
+        ) -> tuple[SiteSignals | None, ProviderRunMetadata]:
+            return None, ProviderRunMetadata(
+                status="failed",
+                latency_ms=0,
+                error="blocked_by_antibot (HTTP 403)",
+                provider_version=self.version,
+            )
+
+    class _EmptyBodyProxy:
+        slug: ClassVar[str] = "smart_proxy_empty"
+        category: ClassVar[Literal["smart_proxy"]] = "smart_proxy"
+        cost_hint: ClassVar[Literal["per-call"]] = "per-call"
+        version: ClassVar[str] = "0.1.0"
+
+        def fetch(self, url: str, *, ctx: FetchContext) -> tuple[bytes | None, ProviderRunMetadata]:
+            return b"<!DOCTYPE html><html><head></head><body></body></html>", (
+                ProviderRunMetadata(status="ok", latency_ms=1, provider_version=self.version)
+            )
+
+    env = core.run(
+        "any.example",
+        mock=True,
+        fixtures_dir=tmp_path,
+        providers=_reg(
+            site_text_blocked=_BlockedPrimary,
+            smart_proxy_empty=_EmptyBodyProxy,
+        ),
+        fetched_at=FIXED_WHEN,
+    )
+    proxy_row = env.provenance["smart_proxy_empty"]
+    assert proxy_row.status == "failed"
+    assert proxy_row.error == "empty_response"
+    assert env.data.pages is None
+    assert env.status in {"degraded", "partial"}
+    assert env.error is not None
+
+
+def test_empty_response_gate_measures_utf8_bytes_not_chars(tmp_path: Path) -> None:
+    """Multibyte prose must not false-positive as empty.
+
+    30 Japanese characters encode to 90 UTF-8 bytes — comfortably above
+    the 64-byte cutoff. Counting ``len(text)`` instead of
+    ``len(text.encode("utf-8"))`` would mis-flag this as empty_response.
+    """
+    slug = "cjkprobe"
+    site_dir = tmp_path / slug
+    site_dir.mkdir()
+    # 30 katakana chars = 90 UTF-8 bytes; extractor passes them through.
+    body_text = "カタカナ" * 8  # 32 chars, 96 bytes
+    (site_dir / "homepage.html").write_text(
+        f"<html><body><p>{body_text}</p></body></html>", encoding="utf-8"
+    )
+
+    env = core.run(
+        f"{slug}.example",
+        mock=True,
+        fixtures_dir=tmp_path,
+        providers=_reg(site_text_trafilatura=TrafilaturaProvider),
+        fetched_at=FIXED_WHEN,
+    )
+    assert env.status == "ok", env.error
+    assert env.data.pages is not None
+    assert body_text in env.data.pages.homepage_text
+
+
 def test_empty_response_does_not_trigger_smart_proxy_retry() -> None:
     """A failed site_text row with ``error == "empty_response"`` must not be
     routed to the smart-proxy recovery path — the fetch already worked, the

--- a/tests/test_core_orchestrator.py
+++ b/tests/test_core_orchestrator.py
@@ -365,9 +365,13 @@ def test_ignore_robots_bypasses_robots_check(monkeypatch: pytest.MonkeyPatch) ->
         "companyctx.providers.site_text_trafilatura.is_allowed",
         lambda url, user_agent: False,
     )
+    # Keep the body comfortably above ``EMPTY_RESPONSE_BYTES`` (COX-44)
+    # so this test stays about the robots-bypass path, not the
+    # empty-response honesty check.
+    body_text = "Hello from the ignore-robots smoke path — this is long enough to clear the cutoff."
     monkeypatch.setattr(
         "companyctx.providers.site_text_trafilatura.requests.get",
-        lambda *args, **kwargs: _FakeResponse("<html><body>Hello</body></html>"),
+        lambda *args, **kwargs: _FakeResponse(f"<html><body><p>{body_text}</p></body></html>"),
     )
     env = core.run(
         "https://example.com",
@@ -377,7 +381,7 @@ def test_ignore_robots_bypasses_robots_check(monkeypatch: pytest.MonkeyPatch) ->
     )
     assert env.status == "ok"
     assert env.data.pages is not None
-    assert env.data.pages.homepage_text == "Hello"
+    assert body_text in env.data.pages.homepage_text
 
 
 def test_provider_rejects_unsupported_scheme() -> None:
@@ -534,6 +538,113 @@ def test_cli_validate_rejects_extra_field(tmp_path: Path) -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["validate", str(path)])
     assert result.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    ("homepage_html", "expect_empty"),
+    [
+        # Zero visible body — trafilatura returns nothing, BS fallback also
+        # yields "". 0 < 64 → empty_response trips.
+        ("<!DOCTYPE html><html><head></head><body></body></html>", True),
+        # Login-wall stub shape: visible text is under the 64-byte cutoff.
+        ("<html><body><p>Please sign in</p></body></html>", True),
+        # Just above the cutoff: ~80 bytes of visible prose. Must NOT trip.
+        (
+            "<html><body><p>"
+            + ("We bake bread in Portland. We cater weddings and supply local cafes daily." * 1)
+            + "</p></body></html>",
+            False,
+        ),
+    ],
+)
+def test_empty_response_trips_honesty_check(
+    tmp_path: Path, homepage_html: str, expect_empty: bool
+) -> None:
+    """COX-44 — extracted text below EMPTY_RESPONSE_BYTES surfaces as
+    ``error.code == "empty_response"`` instead of a silent ``status: ok``.
+    Above the cutoff the envelope stays ``ok``. Regression guard on the
+    exact threshold behavior that retires the v0.2 Known Limitations
+    disclosure.
+    """
+    slug = "emptyprobe"
+    site_dir = tmp_path / slug
+    site_dir.mkdir()
+    (site_dir / "homepage.html").write_text(homepage_html, encoding="utf-8")
+
+    env = core.run(
+        f"{slug}.example",
+        mock=True,
+        fixtures_dir=tmp_path,
+        providers=_reg(site_text_trafilatura=TrafilaturaProvider),
+        fetched_at=FIXED_WHEN,
+    )
+    if expect_empty:
+        assert env.status == "degraded"
+        assert env.error is not None
+        assert env.error.code == "empty_response"
+        assert env.error.suggestion is not None
+        assert "HTTP 200" in env.error.suggestion
+        row = env.provenance["site_text_trafilatura"]
+        assert row.status == "failed"
+        assert row.error == "empty_response"
+        assert env.data.pages is None
+    else:
+        assert env.status == "ok"
+        assert env.error is None
+        assert env.data.pages is not None
+        assert env.data.pages.homepage_text
+
+
+def test_empty_response_does_not_trigger_smart_proxy_retry() -> None:
+    """A failed site_text row with ``error == "empty_response"`` must not be
+    routed to the smart-proxy recovery path — the fetch already worked, the
+    site returned nothing. Automatic retry on empty is explicitly out of
+    scope for COX-44; agents decide what to do.
+    """
+
+    class _EmptyResponseProvider:
+        slug: ClassVar[str] = "site_text_empty"
+        category: ClassVar[Literal["site_text"]] = "site_text"
+        cost_hint: ClassVar[Literal["free"]] = "free"
+        version: ClassVar[str] = "0.1.0"
+
+        def fetch(
+            self, site: str, *, ctx: FetchContext
+        ) -> tuple[SiteSignals | None, ProviderRunMetadata]:
+            return None, ProviderRunMetadata(
+                status="failed",
+                latency_ms=0,
+                error="empty_response",
+                provider_version=self.version,
+            )
+
+    proxy_calls: list[str] = []
+
+    class _RecordingProxy:
+        slug: ClassVar[str] = "smart_proxy_record"
+        category: ClassVar[Literal["smart_proxy"]] = "smart_proxy"
+        cost_hint: ClassVar[Literal["per-call"]] = "per-call"
+        version: ClassVar[str] = "0.1.0"
+
+        def fetch(self, url: str, *, ctx: FetchContext) -> tuple[bytes | None, ProviderRunMetadata]:
+            proxy_calls.append(url)
+            return b"<html><body>recovered</body></html>", ProviderRunMetadata(
+                status="ok", latency_ms=1, provider_version=self.version
+            )
+
+    env = core.run(
+        "any.example",
+        mock=True,
+        providers=_reg(
+            site_text_empty=_EmptyResponseProvider,
+            smart_proxy_record=_RecordingProxy,
+        ),
+        fetched_at=FIXED_WHEN,
+    )
+    assert proxy_calls == []
+    assert env.status == "degraded"
+    assert env.error is not None
+    assert env.error.code == "empty_response"
 
 
 def test_cli_providers_list_shows_registered_provider() -> None:

--- a/tests/test_core_orchestrator.py
+++ b/tests/test_core_orchestrator.py
@@ -648,7 +648,16 @@ def test_empty_response_applies_to_smart_proxy_recovery(tmp_path: Path) -> None:
     assert proxy_row.error == "empty_response"
     assert env.data.pages is None
     assert env.status in {"degraded", "partial"}
+    # Terminal-signal rule: the primary row carries
+    # ``blocked_by_antibot`` (the trigger for the proxy retry), but the
+    # waterfall's terminal failure is the proxy's empty body. Envelope-
+    # level ``error.code`` must reflect that, otherwise agents branching
+    # on the envelope see a stale antibot signal and the
+    # smart-proxy-based suggestion when the proxy was actually run.
     assert env.error is not None
+    assert env.error.code == "empty_response"
+    assert env.error.suggestion is not None
+    assert "HTTP 200" in env.error.suggestion
 
 
 def test_empty_response_gate_measures_utf8_bytes_not_chars(tmp_path: Path) -> None:

--- a/tests/test_envelope_error_codes.py
+++ b/tests/test_envelope_error_codes.py
@@ -126,3 +126,7 @@ def test_misconfigured_provider_code_from_not_configured_row() -> None:
 
 def test_no_provider_succeeded_code_for_unclassified_reason() -> None:
     assert _run_with_error("something we do not recognize") == "no_provider_succeeded"
+
+
+def test_empty_response_code_from_provider_error_string() -> None:
+    assert _run_with_error("empty_response") == "empty_response"

--- a/tests/test_envelope_schema.py
+++ b/tests/test_envelope_schema.py
@@ -159,13 +159,13 @@ def test_envelope_rejects_inconsistent_status_and_error(
         Envelope.model_validate(payload)
 
 
-def test_envelope_schema_version_defaults_to_02() -> None:
+def test_envelope_schema_version_defaults_to_03() -> None:
     env = Envelope(
         status="ok",
         data=CompanyContext(site="x", fetched_at=_fixed_dt()),
         provenance={},
     )
-    assert env.schema_version == "0.2.0"
+    assert env.schema_version == "0.3.0"
 
 
 def test_envelope_error_requires_a_valid_code() -> None:

--- a/tests/test_fixtures_corpus.py
+++ b/tests/test_fixtures_corpus.py
@@ -41,12 +41,19 @@ EXPECTED_FILES = (
 # fixtures/README.md ("Failure-shape regressions").
 FM7_FIXTURE_SLUGS = ("fm7-js-redirect-root", "fm7-maintenance-page")
 FM7_FIXTURE_FILES = ("homepage.html", "expected.json")
+# Empty-response fixtures exercise the COX-44 honesty check: a successful
+# fetch whose extracted text is below ``EMPTY_RESPONSE_BYTES`` surfaces as
+# ``error.code == "empty_response"`` instead of a silent ``status: ok``
+# with zero-length ``homepage_text``. Same on-disk shape as the FM-7
+# fixtures (``homepage.html`` + ``expected.json``).
+EMPTY_RESPONSE_FIXTURE_SLUGS = ("empty-response",)
+EMPTY_RESPONSE_FIXTURE_FILES = ("homepage.html", "expected.json")
 # Block-style fixtures use the `fixture-block.txt` sentinel honored by
 # site_text_trafilatura._from_fixture (issue #40). They carry no
 # homepage.html — the sentinel raises before any HTML is read.
 BLOCK_FIXTURE_SLUGS = ("fm13-timeout-smb-01",)
 BLOCK_FIXTURE_FILES = ("fixture-block.txt", "expected.json")
-FAILURE_FIXTURE_SLUGS = FM7_FIXTURE_SLUGS + BLOCK_FIXTURE_SLUGS
+FAILURE_FIXTURE_SLUGS = FM7_FIXTURE_SLUGS + EMPTY_RESPONSE_FIXTURE_SLUGS + BLOCK_FIXTURE_SLUGS
 
 # Real-golden fixtures (issue #24) live alongside the 30 synthetic dirs but
 # are hand-curated, not generated. They carry a ``.hand-curated`` marker and
@@ -106,6 +113,11 @@ def test_failure_fixtures_have_minimum_files() -> None:
         site_dir = FIXTURES_DIR / slug
         assert site_dir.is_dir(), slug
         missing = [f for f in FM7_FIXTURE_FILES if not (site_dir / f).exists()]
+        assert not missing, f"{slug} missing {missing}"
+    for slug in EMPTY_RESPONSE_FIXTURE_SLUGS:
+        site_dir = FIXTURES_DIR / slug
+        assert site_dir.is_dir(), slug
+        missing = [f for f in EMPTY_RESPONSE_FIXTURE_FILES if not (site_dir / f).exists()]
         assert not missing, f"{slug} missing {missing}"
     for slug in BLOCK_FIXTURE_SLUGS:
         site_dir = FIXTURES_DIR / slug

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -32,7 +32,7 @@ from companyctx import (
 
 
 def test_top_level_reexports_are_importable() -> None:
-    assert SCHEMA_VERSION == "0.2.0"
+    assert SCHEMA_VERSION == "0.3.0"
     assert Envelope.__name__ == "Envelope"
     assert EnvelopeError.__name__ == "EnvelopeError"
     for cls in (
@@ -58,7 +58,8 @@ def test_top_level_literal_aliases_expose_expected_members() -> None:
     assert "not_configured" in get_args(ProviderStatus)
     assert "press" in get_args(MentionKind)
     assert "award" in get_args(MentionKind)
-    # All 7 v0.2 error codes must stay re-exported.
+    # Every v0.3 error code must stay re-exported. ``empty_response`` is
+    # the v0.3 addition — COX-44 / #79.
     for code in (
         "ssrf_rejected",
         "network_timeout",
@@ -67,6 +68,7 @@ def test_top_level_literal_aliases_expose_expected_members() -> None:
         "response_too_large",
         "no_provider_succeeded",
         "misconfigured_provider",
+        "empty_response",
     ):
         assert code in get_args(EnvelopeErrorCode), code
 

--- a/tests/test_regression_corpus.py
+++ b/tests/test_regression_corpus.py
@@ -56,6 +56,15 @@ REGRESSION_SLUGS = (
     # content from an effectively empty page.
     "fm7-js-redirect-root",
     "fm7-maintenance-page",
+    # COX-44 empty-response honesty regression. With the v0.3 provider
+    # gate, an HTTP 200 that extracts to < EMPTY_RESPONSE_BYTES flips from
+    # the v0.2 silent-success shape (status: ok, homepage_text: "") to the
+    # honest shape: status: degraded, error.code: "empty_response" with an
+    # actionable suggestion. The fm7-* fixtures above also exercise this
+    # code path post-COX-44; this dedicated fixture is the minimal,
+    # zero-content trigger so the pin survives a future fm7-* semantic
+    # rename. See docs/SPEC.md §empty_response.
+    "empty-response",
     # FM-13 network-failure regression. Driven by the fixture-block.txt
     # sentinel honoured by site_text_trafilatura._from_fixture: the file's
     # contents become the BlockedError reason verbatim, the provider maps

--- a/tests/test_smart_proxy_http.py
+++ b/tests/test_smart_proxy_http.py
@@ -113,7 +113,14 @@ class _ProxyRecoversSite:
     category: ClassVar[Literal["smart_proxy"]] = "smart_proxy"
     cost_hint: ClassVar[Literal["per-call"]] = "per-call"
     version: ClassVar[str] = "0.1.0"
-    RECOVERED_HTML = b"<html><body><h1>Recovered Biz</h1><p>hello via proxy</p></body></html>"
+    # Keep the recovered prose above ``EMPTY_RESPONSE_BYTES`` (COX-44) so
+    # recovery tests stay about the waterfall wiring, not the empty-
+    # response gate on Attempt 2.
+    RECOVERED_HTML = (
+        b"<html><body><h1>Recovered Biz</h1>"
+        b"<p>hello via proxy -- this recovery body is long enough to clear the cutoff</p>"
+        b"</body></html>"
+    )
 
     def fetch(
         self,
@@ -313,7 +320,9 @@ def _blocked_fixture(tmp_path: Path, slug: str, *, with_homepage: bool) -> None:
     (site_dir / "fixture-block.txt").write_text("blocked_by_antibot (HTTP 403)", encoding="utf-8")
     if with_homepage:
         (site_dir / "homepage.html").write_bytes(
-            b"<html><body><h1>Recovered</h1><p>proxy win</p></body></html>"
+            b"<html><body><h1>Recovered</h1>"
+            b"<p>proxy win -- recovered body long enough to clear the empty-response cutoff</p>"
+            b"</body></html>"
         )
 
 

--- a/tests/test_smart_proxy_http.py
+++ b/tests/test_smart_proxy_http.py
@@ -405,8 +405,12 @@ def test_waterfall_skips_smart_proxy_when_site_text_ok(
     slug = "cleanfix"
     site_dir = tmp_path / slug
     site_dir.mkdir()
+    # Body clears the v0.3 ``EMPTY_RESPONSE_BYTES`` cutoff so this test
+    # stays about the smart-proxy skip path, not the empty-response check.
     (site_dir / "homepage.html").write_bytes(
-        b"<html><body><h1>Clean Biz</h1><p>hello</p></body></html>"
+        b"<html><body><h1>Clean Biz</h1>"
+        b"<p>hello from the clean-path homepage, long enough to clear the cutoff</p>"
+        b"</body></html>"
     )
     monkeypatch.setenv(ENV_URL, "http://user:pass@host:7777")
 
@@ -829,8 +833,13 @@ def test_site_meta_failure_does_not_trigger_recovery(
     slug = "metaok"
     site_dir = tmp_path / slug
     site_dir.mkdir()
+    # Body clears ``EMPTY_RESPONSE_BYTES`` so the zero-key provider
+    # completes with ``ok`` — this test is about site_meta failures not
+    # being routed to smart-proxy recovery, not about empty responses.
     (site_dir / "homepage.html").write_bytes(
-        b"<html><body><h1>Real Biz</h1><p>full homepage</p></body></html>"
+        b"<html><body><h1>Real Biz</h1>"
+        b"<p>full homepage prose long enough to clear the empty-response cutoff</p>"
+        b"</body></html>"
     )
     monkeypatch.setenv(ENV_URL, "http://user:pass@host:7777")
 


### PR DESCRIPTION
## Summary
- Adds `empty_response` to the closed `EnvelopeError.code` Literal and bumps `SCHEMA_VERSION` to `"0.3.0"` — a minor envelope bump per the new-code rule in `docs/SPEC.md`.
- Zero-key `site_text_trafilatura` (Attempt 1) and the smart-proxy recovery path (Attempt 2) now share an `is_empty_response` gate in `companyctx.extract`. Below `EMPTY_RESPONSE_BYTES = 64` **UTF-8 bytes** (not chars), the provider row surfaces `status: "failed"`, `error: "empty_response"` instead of letting a zero-length `homepage_text` flow through as `status: "ok"`.
- Orchestrator classifies `empty_response` into `error.code` with a code-specific suggestion ("site returned HTTP 200 with effectively no content; try `--ignore-robots` or check with a browser"). When multiple failures are present, `empty_response` wins the top-level code as the terminal waterfall signal (the antibot block was the trigger; the empty proxy body is what the pipeline actually ended on). Automatic smart-proxy retry on an Attempt-1 empty is out of scope — the recovery path skips `empty_response` rows.
- One new regression fixture (`fixtures/empty-response/`), plus parametrized threshold coverage, Attempt-2 recovery coverage, UTF-8 multibyte coverage, and the 8th entry in `test_envelope_error_codes`. All 38 `expected.json` files refreshed to `schema_version: "0.3.0"`; the fm7-* fixtures now pin the honest `status: degraded` / `empty_response` shape instead of the v0.2 silent-success shape.
- Retires the "empty-body silent-success" disclosure from v0.2.0 Known Limitations (the release-notes edit itself ships with the v0.3 release PR).

## Commits
- e364a0b — feat(schema): add empty_response code + bump schema_version to 0.3.0
- b80c2d3 — feat(site_text): gate on EMPTY_RESPONSE_BYTES to stop silent-success
- 6c34257 — feat(core): classify empty_response and skip smart-proxy retry
- 5cd0cdb — chore(fixtures): regenerate expected envelopes + add empty-response pin
- fcdd060 — test: cover empty_response across orchestrator, codes, and fixtures
- 8511097 — docs: document empty_response code + threshold
- 8a13441 — fix(core): close two empty_response gaps from review
- 840e6bc — test: cover Attempt-2 empty gate + multibyte threshold
- 732e385 — docs: clarify empty_response gate applies to both waterfall attempts
- 72236b0 — fix(core): prefer empty_response as terminal envelope code

## Acceptance (from #79)
- [x] `empty_response` literal added to `EnvelopeError.code`.
- [x] Provider returns it when extracted-text length < threshold (`EMPTY_RESPONSE_BYTES = 64` UTF-8 bytes).
- [x] Top-level envelope has `status: degraded` + `error.code: empty_response` + an actionable suggestion ("site returned HTTP 200 with effectively no content; try `--ignore-robots` or check with a browser").
- [x] One regression fixture (`fixtures/empty-response/`) + unit test (parametrized; the fm7-* regressions also pin the new honest shape).
- [x] `docs/SPEC.md` documents the new code + threshold (plus the UTF-8-byte rule, the Attempt-1+2 coverage, and the terminal-signal rule).
- [x] CI green — expected on push.
- [ ] v0.3.0 release notes retire the "Known limitations — empty-body silent-success" disclosure — **deferred to the v0.3 release PR** (package `__version__` stays `0.2.0` here; the release PR bumps it alongside cutting the tag).

## Test plan
- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy companyctx tests` clean (33 source files, no issues)
- [x] `pytest -q` — 241 tests passed
- [x] Two reviewer-reproduced regressions (Attempt-2 silent-success on empty proxy body; UTF-8-byte vs char count false-positive on CJK) now have dedicated tests in `tests/test_core_orchestrator.py`
- [x] Terminal-signal rule (`blocked_by_antibot` Attempt 1 → `empty_response` Attempt 2 → envelope `error.code == "empty_response"`) asserted in `test_empty_response_applies_to_smart_proxy_recovery`
- [x] `--mock` determinism preserved: all 38 `expected.json` files regenerated with `scripts/build-fixtures.py --synthetic` (30 synthetic) or orchestrator output (fm7-*, empty-response), manual `schema_version` bump for fm13-* and the 5 real-golden fixtures

## Breaking changes
Envelope `schema_version: "0.2.0"` payloads no longer validate under `extra="forbid"` against the v0.3 `Envelope` model — the Literal tightens to `"0.3.0"`. This is a minor schema bump per the new-code rule; agents already branch on `schema_version` per `docs/SPEC.md`. Package `__version__` stays `0.2.0` until the v0.3 release PR.

Closes #79