### PR TITLE
fix(schema)!: require schema_version, remove default (COX-47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code to the closed `EnvelopeError.code` Literal is a minor schema
   bump. v0.2.0 envelopes still validate under the old Literal but the
   orchestrator now emits `"0.3.0"` on every run.
+- **`Envelope.schema_version` is now required; the literal default has
+  been removed.** A missing, `null`, or empty-string `schema_version` now
+  fails `Envelope.model_validate_json` with a `ValidationError`, and every
+  `Envelope(...)` constructor site must pass `schema_version="0.3.0"`
+  explicitly. The prior default silently let pre-v0.2 envelopes (no
+  `schema_version`, bare-string `error`) validate as current, defeating
+  the whole point of a shape discriminator — agents saw the literal
+  stamped on a stale envelope and made wrong assumptions about
+  version-gated fields. The published JSON Schema (`companyctx schema`)
+  now lists `schema_version` in the `required` array. Lands with the v0.3
+  minor bump; downstream call sites that build envelopes programmatically
+  must pass the kwarg. Closes COX-47 / #84.
 - **New `empty_response` error code (COX-44 / #79).** Both waterfall
   attempts now gate on extracted-text UTF-8 byte length against
   `EMPTY_RESPONSE_BYTES = 64`. Zero-key `site_text_trafilatura`

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -28,6 +28,7 @@ from companyctx.extract import (
 from companyctx.providers import discover
 from companyctx.providers.base import FetchContext, ProviderBase
 from companyctx.schema import (
+    SCHEMA_VERSION,
     CompanyContext,
     Envelope,
     EnvelopeError,
@@ -181,6 +182,7 @@ def run(
         status = _aggregate_status(provenance, registry, recovered_slugs)
         error = _build_envelope_error(status, provenance)
         return Envelope(
+            schema_version=SCHEMA_VERSION,
             status=status,
             data=data,
             provenance=provenance,
@@ -567,6 +569,7 @@ def _fallback_envelope(
             suggestion=_suggestion_for("no_provider_succeeded"),
         )
     return Envelope(
+        schema_version=SCHEMA_VERSION,
         status=status,
         data=CompanyContext(site=site, fetched_at=when),
         provenance=dict(provenance),

--- a/companyctx/schema.py
+++ b/companyctx/schema.py
@@ -156,7 +156,7 @@ class Envelope(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["0.3.0"] = "0.3.0"
+    schema_version: Literal["0.3.0"]
     status: EnvelopeStatus
     data: CompanyContext
     provenance: dict[str, ProviderRunMetadata] = Field(default_factory=dict)

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -31,9 +31,9 @@ class Envelope(BaseModel):
     error: EnvelopeError | None = None
 ```
 
-`schema_version` is **required**. A missing or `null` value fails
-validation — a default would let pre-v0.2 envelopes silently validate as
-current. See `docs/SPEC.md` for the full rationale.
+`schema_version` is **required**. A missing, `null`, or empty-string
+value fails validation — a default would let pre-v0.2 envelopes silently
+validate as current. See `docs/SPEC.md` for the full rationale.
 
 Status semantics:
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -24,12 +24,16 @@ Every `companyctx fetch` invocation returns one wrapper around the payload:
 
 ```python
 class Envelope(BaseModel):
-    schema_version: Literal["0.3.0"] = "0.3.0"
+    schema_version: Literal["0.3.0"]    # required — no default
     status: Literal["ok", "partial", "degraded"]
     data: CompanyContext
     provenance: dict[str, ProviderRunMetadata]
     error: EnvelopeError | None = None
 ```
+
+`schema_version` is **required**. A missing or `null` value fails
+validation — a default would let pre-v0.2 envelopes silently validate as
+current. See `docs/SPEC.md` for the full rationale.
 
 Status semantics:
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -148,12 +148,24 @@ invent content). Agents decide whether to retry upstream.
 
 Every envelope carries a top-level `schema_version: Literal["0.3.0"]`.
 Agents branch on shape by reading this field directly — no substring-
-parsing an error string. Adding an optional envelope field is a PATCH (no
-`schema_version` bump); adding or renaming an `EnvelopeError.code` is a
-MINOR bump; changing or removing an existing field is a MAJOR bump.
-v0.3.0 adds the `empty_response` code to the closed set — a minor bump
-from v0.2.0. v0.1 envelopes lack the `schema_version` field and fail
-validation under `extra="forbid"`.
+parsing an error string.
+
+**The field is REQUIRED. There is no default.** A missing, `null`, or
+empty-string `schema_version` fails validation at parse time with a
+`ValidationError`. This is deliberate: a default value would let pre-v0.3
+envelopes (which lack the field entirely, or carry the older `"0.2.0"`
+literal) silently validate as current, defeating the point of a shape
+discriminator. The constructor signature in `companyctx/schema.py` is the
+source of truth — every call site must pass `schema_version="0.3.0"`
+explicitly. Published JSON Schema (`companyctx schema`) lists
+`schema_version` in the `required` array.
+
+Adding an optional envelope field is a PATCH (no `schema_version` bump);
+adding or renaming an `EnvelopeError.code` is a MINOR bump; changing or
+removing an existing field is a MAJOR bump. v0.3.0 adds the
+`empty_response` code to the closed set — a minor bump from v0.2.0. v0.1
+envelopes lack the `schema_version` field and fail validation under
+`extra="forbid"` plus the required-field check.
 
 ### `providers list` output shape
 

--- a/tests/test_envelope_schema.py
+++ b/tests/test_envelope_schema.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 
 import pytest
@@ -28,6 +29,7 @@ def _fixed_dt() -> datetime:
 
 def test_envelope_round_trips_through_json() -> None:
     env = Envelope(
+        schema_version="0.3.0",
         status="ok",
         data=CompanyContext(
             site="example.com",
@@ -69,6 +71,7 @@ def test_envelope_round_trips_through_json() -> None:
         (
             Envelope,
             {
+                "schema_version": "0.3.0",
                 "status": "ok",
                 "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
                 "provenance": {},
@@ -129,12 +132,14 @@ def test_provider_run_metadata_is_frozen() -> None:
     [
         # status=partial but no structured error.
         {
+            "schema_version": "0.3.0",
             "status": "partial",
             "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
             "provenance": {},
         },
         # status=degraded with a bare string in `error` (pre-v0.2 shape).
         {
+            "schema_version": "0.3.0",
             "status": "degraded",
             "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
             "provenance": {},
@@ -142,6 +147,7 @@ def test_provider_run_metadata_is_frozen() -> None:
         },
         # status=ok must not carry an error.
         {
+            "schema_version": "0.3.0",
             "status": "ok",
             "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
             "provenance": {},
@@ -159,13 +165,70 @@ def test_envelope_rejects_inconsistent_status_and_error(
         Envelope.model_validate(payload)
 
 
-def test_envelope_schema_version_defaults_to_03() -> None:
+def test_envelope_schema_version_set_explicitly() -> None:
     env = Envelope(
+        schema_version="0.3.0",
         status="ok",
         data=CompanyContext(site="x", fetched_at=_fixed_dt()),
         provenance={},
     )
     assert env.schema_version == "0.3.0"
+
+
+def test_envelope_requires_schema_version_keyword() -> None:
+    # COX-47: schema_version has no default. Omitting it at construction time
+    # must raise — silent "upgrade" of a v0.1-shaped envelope is the bug.
+    with pytest.raises(ValidationError) as excinfo:
+        Envelope(  # type: ignore[call-arg]
+            status="ok",
+            data=CompanyContext(site="x", fetched_at=_fixed_dt()),
+            provenance={},
+        )
+    assert "schema_version" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        # Field completely absent from the JSON payload (v0.1-shaped).
+        lambda body: body,
+        # Field present but explicit JSON null.
+        lambda body: {**body, "schema_version": None},
+        # Field present but empty string — fails the Literal["0.3.0"] check.
+        lambda body: {**body, "schema_version": ""},
+    ],
+    ids=["missing_field", "null_value", "empty_string"],
+)
+def test_envelope_rejects_missing_or_empty_schema_version(
+    mutate: object,
+) -> None:
+    # COX-47: the Literal rejected wrong values already; the default used to
+    # accept missing ones. All three variants must now fail at parse time.
+    body = {
+        "status": "ok",
+        "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
+        "provenance": {},
+    }
+    payload = json.dumps(mutate(body))  # type: ignore[operator]
+    with pytest.raises(ValidationError) as excinfo:
+        Envelope.model_validate_json(payload)
+    assert "schema_version" in str(excinfo.value)
+
+
+def test_envelope_rejects_v0_1_shaped_payload() -> None:
+    # COX-47: A pre-v0.2 envelope (no schema_version, error as a bare string
+    # instead of a structured EnvelopeError) must not silently validate. The
+    # missing schema_version is the first tripwire; the bare-string error is
+    # rejected too under extra="forbid" / type mismatch.
+    v0_1_payload = {
+        "status": "degraded",
+        "data": {"site": "x", "fetched_at": _fixed_dt().isoformat()},
+        "provenance": {},
+        "error": "no providers succeeded",
+        "suggestion": "configure a smart-proxy provider key",
+    }
+    with pytest.raises(ValidationError):
+        Envelope.model_validate(v0_1_payload)
 
 
 def test_envelope_error_requires_a_valid_code() -> None:
@@ -180,6 +243,7 @@ def test_envelope_error_rejects_unknown_fields() -> None:
 
 def test_envelope_error_round_trips() -> None:
     env = Envelope(
+        schema_version="0.3.0",
         status="partial",
         data=CompanyContext(site="x", fetched_at=_fixed_dt()),
         provenance={},

--- a/tests/test_schema_verb.py
+++ b/tests/test_schema_verb.py
@@ -51,6 +51,12 @@ def test_schema_verb_emits_draft_2020_12_json_schema() -> None:
     props = payload.get("properties", {})
     for field in ("schema_version", "status", "data", "provenance", "error"):
         assert field in props, field
+    # COX-47: schema_version MUST be in the ``required`` array. A missing
+    # ``required`` entry lets a v0.1 envelope (no ``schema_version``) pass as
+    # v0.2 — the honesty bug this issue fixes at the Pydantic layer must also
+    # show up in the externally-published JSON Schema.
+    required = payload.get("required", [])
+    assert "schema_version" in required, required
 
 
 def test_schema_verb_validates_regression_fixture_envelope() -> None:


### PR DESCRIPTION
## Summary
- `Envelope.schema_version` is now a bare `Literal["0.3.0"]` — no default. A missing, `null`, or empty-string value now fails `Envelope.model_validate_json` with a `ValidationError` that names the field.
- Every `Envelope(...)` constructor site (two in `companyctx/core.py`, five in test helpers) passes `schema_version=SCHEMA_VERSION` explicitly; the published JSON Schema (`companyctx schema`) now lists `schema_version` in the `required` array.
- Closes the silent-upgrade bug from COX-47: a v0.1-shaped envelope (no `schema_version`, bare-string `error`) previously got `"0.2.0"` stamped on by the default and passed `companyctx validate` as current — agents downstream trusted the stale shape and misread v0.2-only fields. Now it fails loudly at parse time.
- Parametrized test covers all three "missing-or-empty" variants plus a dedicated v0.1-shaped payload tripwire and the JSON-Schema `required`-array assertion.
- Rebased onto `main` after #83 shipped: literal pinned to `"0.3.0"` throughout; CHANGELOG entry folded into the v0.3 Unreleased section (not a v0.2.1 patch anymore).

## Commits
- `bd74d30` — fix(schema)!: require schema_version, remove "0.2.0" default
- `d16fae7` — test(schema): assert schema_version is required at parse time
- `2dbd645` — docs: document schema_version as required with no default
- `8321818` — docs: align SCHEMA.md missing/null/empty wording with SPEC.md

## Acceptance (from #84)
- [x] `schema_version` has no default in `Envelope`.
- [x] All `Envelope(...)` constructor sites pass it explicitly. Tests still green.
- [x] Missing-field, null-field, and empty-string-field JSON all fail `model_validate_json` with `ValidationError`.
- [x] v0.1-shaped envelope JSON (no `schema_version`, no structured `error`) rejected at parse time with a test fixture.
- [x] `docs/SPEC.md` documents "no default" explicitly.
- [x] `companyctx schema` output lists `schema_version` in the `required` array.
- [x] CHANGELOG entry — folded into the `[Unreleased]` v0.3 "envelope schema bump" section on rebase (issue body framed this as a v0.2.1 patch, but #83 already shipped the v0.3 bump to `main`, so the tightening lands in the same minor).
- [ ] CI green on all three Python versions — awaiting CI on this PR.
- [x] PR title uses `fix!` + `BREAKING CHANGE:` footer on the lead commit.

## Test plan
- [x] `ruff format --check .` clean (40 files formatted)
- [x] `ruff check .` clean
- [x] `mypy companyctx tests` clean (no issues in 33 source files)
- [x] `pytest -q` — 246 tests passed (post-rebase; includes #83's new coverage)

## Breaking changes
Callers constructing `Envelope()` directly in Python must now pass `schema_version="0.3.0"`; omitting the kwarg raises `ValidationError`. Parsers handed JSON without the field (or with `null` / `""`) raise `ValidationError` instead of silently upgrading. Migration: update call sites and any persisted envelopes — there is intentionally no v0.1→v0.3 migration helper (re-fetch is the supported path).

Closes #84.