### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `companyctx` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] — 2026-04-23
 
 ### Changed — envelope schema bump (v0.3)
 

--- a/companyctx/__init__.py
+++ b/companyctx/__init__.py
@@ -21,7 +21,7 @@ from companyctx.schema import (
     SocialSignals,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "SCHEMA_VERSION",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "companyctx"
-version = "0.2.0"
+version = "0.3.0"
 description = "Deterministic B2B context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -73,8 +73,9 @@ def test_top_level_literal_aliases_expose_expected_members() -> None:
         assert code in get_args(EnvelopeErrorCode), code
 
 
-def test_package_version_is_020() -> None:
-    assert __version__ == "0.2.0"
+def test_package_version_is_current() -> None:
+    """Pinned to current release — bump in the version-bump PR."""
+    assert __version__ == "0.3.0"
 
 
 def test_py_typed_marker_ships_with_package() -> None:


### PR DESCRIPTION
## Summary

Promotes the package from \`0.2.0\` → \`0.3.0\`. Bundles content merged to \`main\` since the v0.2.0 tag (2026-04-22).

## v0.3.0 contents

| PR | What |
|---|---|
| #80 | Docs honesty pass + \`providers list\` enrichment |
| #83 | \`empty_response\` error code + schema_version bump to \`"0.3.0"\` |
| #88 | \`schema_version\` required, default removed |
| #90 | Partner-integration validation research (209 sites) |
| #92 | Google Places reviews direct-API provider — first Attempt-3 tier live |
| #49 / #50 / #51 / #52 | Dependabot GH Actions majors |

## Breaking changes (envelope contract)

- \`schema_version\` Literal bumped \`"0.2.0"\` → \`"0.3.0"\`. Consumers that persisted v0.2 envelopes must re-fetch.
- \`schema_version\` now required; missing-field JSON fails parse.
- \`Envelope.error\` is a structured \`EnvelopeError\` with \`code\` / \`message\` / \`suggestion\`, not a plain \`str | None\`.

## Known limitations (unchanged from v0.2 framing)

- **FM-7 empty_response floor is 64 bytes**; the 19.6 % thin-body rate measured in the v0.2 partner-integration validation (\`research/2026-04-22-v0.2-joel-integration-validation.md\`) is above that floor. **Full floor correction to 1024 bytes ships as v0.3.1 via #91**, tight release after this one.

## Not in this release

- SQLite cache (#9 / PR #93) — coming in v0.4 (PR currently conflicting, needs rebase).
- FM-7 floor correction (#91) — coming in v0.3.1 (immediately after this).

## RC sanity (pre-push)

- \`python -m build\` ✓ wheel + sdist produced.
- Fresh-venv install: \`pip install dist/companyctx-0.3.0-py3-none-any.whl\` ✓.
- \`companyctx --version\` → \`companyctx 0.3.0\` (post-bump).
- \`companyctx providers list\` → 3 providers (\`site_text_trafilatura\` ready, \`reviews_google_places\` + \`smart_proxy_http\` not_configured with clear env-missing reasons).
- \`companyctx schema\` emits valid JSON Schema with \`schema_version\` in \`required\`.
- Live fetch \`example.com\` → \`status: ok\`, \`schema_version: "0.3.0"\`, structured envelope.
- SSRF probe \`10.0.0.1\` → \`error.code: ssrf_rejected\`, clear message.

## Test plan

- [ ] CI green on 3.10 / 3.11 / 3.12 + supply-chain + CodeQL.

## Release choreography (post-merge)

1. \`gh release create v0.3.0 --target main --title "v0.3.0"\` with release notes.
2. Publish workflow fires, pauses on the \`pypi\` Environment reviewer gate.
3. Devon approves.
4. Poll \`pypi.org/pypi/companyctx/0.3.0/json\` until indexed.
5. Verify \`pip install companyctx==0.3.0\` in a fresh venv.