### PR TITLE
docs: add Noontide commercial support section to README (Closes #35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md). Conventional commits, ~400 LOC per
 PR, one PR per milestone or provider. ruff + mypy strict + pytest ≥70% cov.
 Architecture-shape changes go through `decisions/` first.
 
+## Commercial Support & Custom Pipelines
+`companyctx` is built and maintained by **[Noontide](https://noontide.co)**. We use it as the foundational context routing muscle for our own automated B2B outbound engines. 
+If your team needs a fully managed, agentic sales pipeline (Apollo → Context Routing → LLM Synthesis → HubSpot/Outreach) but you don't have the engineering resources to build and maintain the orchestrator yourself, we can help. 
+👉 **[Work with the Noontide Agency to get this built for you.](https://noontide.co)**
+
 ## License
 
 [MIT](LICENSE). Copyright 2026 Noontide Collective LLC.


### PR DESCRIPTION
## Summary
- Insert a "Commercial Support & Custom Pipelines" block directly above `## License` in README.md, using the exact markdown prescribed in the issue body.
- Both links point to `https://noontide.co` with no UTMs / tracking parameters.
- No other README content touched; existing `## Support` (Skool) section left in place.

## Commits
- 64e47dd — docs: add Noontide commercial support section to README (Closes #35)

## Acceptance (from #35)
- [x] Markdown is added to `README.md` directly above the License section.
- [x] Both links point to `https://noontide.co`.
- [x] No tracking parameters are added to the URL.
- [x] Changes are pushed to `main` — delivered via this PR (close-on-merge).

## Test plan
- [x] `ruff format --check .` clean (reported by branch-author)
- [x] `ruff check .` clean (reported by branch-author)
- [x] `mypy companyctx tests` — 3 pre-existing errors in `tests/test_reviews_google_places.py`, unrelated to this docs-only change (confirmed present on `main`)
- [x] `pytest -q` — 323 passed (reported by branch-author)
- [x] Docs-only change; no behavioral surfaces to exercise