### PR TITLE
feat(schema)!: rename fixture traversal error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `companyctx` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed — BREAKING (envelope schema)
+
+- **Renamed `path_traversal_rejected` → `fixture_path_traversal_rejected`
+  in the `EnvelopeError.code` Literal.** The prior code name implied the
+  validator guarded URL-path traversal (`example.com/../etc/passwd`);
+  it never did — the code only fires for `--mock` fixture-slug escapes.
+  Agents pattern-matching on the old string must switch to the new one.
+  No new code was introduced; the behavior is unchanged. URL-path
+  traversal remains out of scope — open a separate issue if a guard is
+  needed. (COX-50 / #87.)
+- **`schema_version` remains `"0.4.0"` on this branch.** The rename is
+  schema-breaking even though the rest of the v0.4 line is already on
+  `main`; `companyctx schema` output, the Pydantic `Envelope(...)`
+  literal, and the fixtures corpus in this branch all advertise the
+  renamed code under the current `0.4.0` envelope discriminator.
+
 ## [0.4.0] — 2026-04-23
 
 v0.4.0 bundles the COX-52 FM-7 floor correction, the COX-49 NXDOMAIN

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,9 +28,10 @@ company so an agent can reason about it, rather than reading raw HTML.
 - Every envelope carries `schema_version`. v0.4 is `"0.4.0"`.
 - When `status != "ok"`, `error` is a structured `{code, message, suggestion}`;
   switch on `error.code` (one of `ssrf_rejected | network_timeout |
-  blocked_by_antibot | path_traversal_rejected | response_too_large |
+  blocked_by_antibot | fixture_path_traversal_rejected | response_too_large |
   no_provider_succeeded | misconfigured_provider | empty_response |
-  cache_corrupted`).
+  cache_corrupted`). `fixture_path_traversal_rejected` only fires on the
+  `--mock` fixture path — URL-path traversal is not guarded by this code.
 - Pipe stdout; don't parse logs. The JSON envelope is the contract.
 - The `data.site` field is the identifier; `data.pages` holds homepage-
   derived content (`homepage_text`, `about_text`, `services`, `tech_stack`).

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -627,9 +627,9 @@ def _classify_error_code(
     if "unsafe_url" in lower or "unsupported scheme" in lower or "invalid site" in lower:
         return "ssrf_rejected"
     if "fixture path escapes" in lower or "fixture file escapes" in lower:
-        return "path_traversal_rejected"
+        return "fixture_path_traversal_rejected"
     if "invalid fixture slug" in lower:
-        return "path_traversal_rejected"
+        return "fixture_path_traversal_rejected"
     if "response_too_large" in lower:
         return "response_too_large"
     if "timeout" in lower:

--- a/companyctx/schema.py
+++ b/companyctx/schema.py
@@ -6,22 +6,20 @@ Every model sets ``extra="forbid"`` so schema drift is loud. See
 frozen spec snapshot.
 
 v0.2.0 introduced the schema-locked envelope (top-level ``schema_version``
-plus structured :class:`EnvelopeError`). v0.3.0 adds two error codes:
+plus structured :class:`EnvelopeError`). v0.3.0 added two error codes:
 ``empty_response`` (so agents can branch on "site returned HTTP 200 with
 effectively no content" instead of mistaking a silent-success for ok data)
 and ``cache_corrupted`` (emitted on the ``--from-cache`` CLI path when the
-cache opens but the row can't be deserialized). v0.4.0 keeps the same
-Literal set but bumps ``SCHEMA_VERSION`` to close the drift the cache
-merge introduced (added ``cache_corrupted`` to the Literal without
-bumping the version constant), and lands alongside the COX-52 FM-7
+cache opens but the row can't be deserialized). v0.4.0 closes the schema-
+version drift the cache merge introduced, lands alongside the COX-52 FM-7
 floor correction (``EMPTY_RESPONSE_BYTES`` 64 → 1024 — same ``Literal``
 members, tighter threshold for ``empty_response``) and the COX-49
 NXDOMAIN routing fix (``unsafe_url:dns_resolve_failure`` →
 ``no_provider_succeeded`` instead of ``ssrf_rejected``; no Literal
-change, classifier-only). Per the closed-set rule, any observable
-change in what ``error.code`` an agent can receive on the same input
-is a minor schema bump — not because the Literal set grew but because
-the mapping from input to code did.
+change, classifier-only), and renames ``path_traversal_rejected`` →
+``fixture_path_traversal_rejected`` to match the code's actual scope
+(``--mock`` fixture-slug escapes only; it does not guard URL-path
+traversal).
 """
 
 from __future__ import annotations
@@ -40,7 +38,7 @@ EnvelopeErrorCode = Literal[
     "ssrf_rejected",
     "network_timeout",
     "blocked_by_antibot",
-    "path_traversal_rejected",
+    "fixture_path_traversal_rejected",
     "response_too_large",
     "no_provider_succeeded",
     "misconfigured_provider",

--- a/companyctx/schema.py
+++ b/companyctx/schema.py
@@ -151,8 +151,11 @@ class EnvelopeError(BaseModel):
     Agents branch on :attr:`code`; humans read :attr:`message`. :attr:`suggestion`
     is an actionable next step (e.g. "configure COMPANYCTX_SMART_PROXY_URL").
 
-    Codes are a closed set. New codes are added in minor releases and bump
-    :data:`SCHEMA_VERSION`; removing or renaming a code is a major bump.
+    Codes are a closed set. Adding, renaming, or removing a code all bump
+    :data:`SCHEMA_VERSION`. In the pre-1.0 (0.x) series, any closed-set
+    change — additive or breaking — lands as a MINOR bump; rename and
+    removal are called out as BREAKING in CHANGELOG. Post-1.0, renames
+    and removals will require a MAJOR bump.
     """
 
     model_config = ConfigDict(extra="forbid")

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -8,6 +8,11 @@ backwards-compatible; removing or renaming a field — or changing the shape of
 an existing one — is a schema-version bump. Always branch on the top-level
 `schema_version` field to detect envelope evolution.
 
+v0.4.0 renames `path_traversal_rejected` →
+`fixture_path_traversal_rejected` to match the validator's actual scope
+(the code only fires for `--mock` fixture-slug escapes; URL-path
+traversal is not guarded). Renaming a code in the closed Literal is
+schema-breaking; v0.4.0 is the minor bump from v0.3.0 carrying it.
 v0.3.0 added two error codes to the closed `EnvelopeError.code` Literal:
 `empty_response` (the silent-success-on-empty gate) and `cache_corrupted`
 (emitted on `--from-cache` when the cache opens but the row can't be
@@ -61,7 +66,7 @@ class EnvelopeError(BaseModel):
         "ssrf_rejected",
         "network_timeout",
         "blocked_by_antibot",
-        "path_traversal_rejected",
+        "fixture_path_traversal_rejected",
         "response_too_large",
         "no_provider_succeeded",
         "misconfigured_provider",
@@ -74,8 +79,13 @@ class EnvelopeError(BaseModel):
 
 Agents should branch on `error.code`; humans read `error.message`.
 `suggestion` is *actionable*: `"configure a smart-proxy provider key"`,
-`"skip this prospect"`. Additional codes are added in minor releases and bump
-`schema_version`; removing or renaming a code is a major bump.
+`"skip this prospect"`. Any closed-set change — adding, renaming, or
+removing a code — bumps `schema_version`. In the pre-1.0 (0.x) series
+all three land as a MINOR bump; rename and removal are called out as
+BREAKING in the CHANGELOG so downstream consumers see the break
+explicitly. A mapping-only change that makes the same input land on a
+different `error.code` is also a MINOR bump. Post-1.0, renames and
+removals will require a MAJOR bump.
 
 ### Example — `ok`
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -102,9 +102,18 @@ Status semantics:
   failure; `error.suggestion` names the next action.
 
 `EnvelopeError.code` is one of `ssrf_rejected | network_timeout |
-blocked_by_antibot | path_traversal_rejected | response_too_large |
+blocked_by_antibot | fixture_path_traversal_rejected | response_too_large |
 no_provider_succeeded | misconfigured_provider | empty_response |
 cache_corrupted`. See `docs/SCHEMA.md` for the shape.
+
+#### `empty_response` (v0.3, floor raised in v0.4.0)
+`fixture_path_traversal_rejected` fires **only** on the `--mock` fixture
+path when the slug escapes `fixtures_dir` (e.g. `companyctx fetch
+"../etc/passwd" --mock`). A live fetch whose URL path contains `../`
+is not guarded by this code — URL-path traversal is out of scope in
+v0.4 (tracking via a follow-up issue if required). The v0.3 code name
+`path_traversal_rejected` implied broader coverage than the validator
+delivered; the rename in v0.4 matches the code to its actual scope.
 
 #### `empty_response` (v0.3, floor raised in v0.4.0)
 
@@ -173,13 +182,18 @@ explicitly. Published JSON Schema (`companyctx schema`) lists
 `schema_version` in the `required` array.
 
 Adding an optional envelope field is a PATCH (no `schema_version` bump);
-adding or renaming an `EnvelopeError.code` is a MINOR bump; changing
-the input → code mapping without adding/renaming codes is also a MINOR
-bump (agents see different behavior for the same input); changing or
-removing an existing field is a MAJOR bump. v0.3.0 added the
-`empty_response` and `cache_corrupted` codes (minor bump from v0.2.0).
-v0.4.0 bumps for two code-mapping changes that keep the Literal set
-constant: the COX-52 FM-7 floor raise (`empty_response` now fires at
+Any change to the closed `EnvelopeError.code` Literal — adding,
+renaming, or removing — bumps `schema_version`. In the pre-1.0 (0.x)
+series all three land as a MINOR bump; rename and removal are called
+out as BREAKING in the CHANGELOG so downstream consumers see the break
+explicitly. A mapping-only change that makes the same input land on a
+different `error.code` is also a MINOR bump. Post-1.0, renames and
+removals will require a MAJOR bump. Changing or removing a non-Literal
+envelope field is always a MAJOR bump. v0.3.0 added the
+`empty_response` and `cache_corrupted` codes to the closed set. v0.4.0
+renames `path_traversal_rejected` → `fixture_path_traversal_rejected`
+to match the validator's actual scope and also carries two mapping-only
+changes: the COX-52 FM-7 floor raise (`empty_response` now fires at
 <1024 UTF-8 bytes, not <64) and the COX-49 NXDOMAIN routing fix
 (`unsafe_url:dns_resolve_failure` now routes to
 `no_provider_succeeded` rather than `ssrf_rejected`). v0.1 envelopes

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -181,8 +181,8 @@ source of truth — every call site must pass `schema_version="0.4.0"`
 explicitly. Published JSON Schema (`companyctx schema`) lists
 `schema_version` in the `required` array.
 
-Adding an optional envelope field is a PATCH (no `schema_version` bump);
-Any change to the closed `EnvelopeError.code` Literal — adding,
+Adding an optional envelope field is a PATCH (no `schema_version`
+bump). Any change to the closed `EnvelopeError.code` Literal — adding,
 renaming, or removing — bumps `schema_version`. In the pre-1.0 (0.x)
 series all three land as a MINOR bump; rename and removal are called
 out as BREAKING in the CHANGELOG so downstream consumers see the break

--- a/scripts/run-error-codes.py
+++ b/scripts/run-error-codes.py
@@ -5,13 +5,14 @@ values deterministically and capture the resulting envelope.
 Two of the codes (``ssrf_rejected``, ``no_provider_succeeded``) fire
 through the public CLI on cold inputs. The remaining five
 (``network_timeout``, ``blocked_by_antibot``, ``response_too_large``,
-``path_traversal_rejected``, ``misconfigured_provider``) need either a
-slow / blocked / oversize upstream, a malicious ``--mock`` slug, or an
-already-failed primary provider — all brittle to reproduce from CLI
-alone. This harness drives ``companyctx.core.run`` with a synthetic
-``ProviderBase`` that emits the exact prefix string the production
-classifier reads (``companyctx/core.py:_classify_error_code``), plus
-the real fixture-path validator for ``path_traversal_rejected``.
+``fixture_path_traversal_rejected``, ``misconfigured_provider``) need
+either a slow / blocked / oversize upstream, a malicious ``--mock``
+slug, or an already-failed primary provider — all brittle to reproduce
+from CLI alone. This harness drives ``companyctx.core.run`` with a
+synthetic ``ProviderBase`` that emits the exact prefix string the
+production classifier reads (``companyctx/core.py:_classify_error_code``),
+plus the real fixture-path validator for
+``fixture_path_traversal_rejected``.
 
 The point is not to test internal code paths — those are covered in
 ``tests/test_envelope_error_codes.py``. The point is to give an
@@ -181,13 +182,13 @@ def trigger_all() -> list[dict]:
         )
     )
 
-    # Case 6 — path_traversal_rejected — real fixture-path validator
+    # Case 6 — fixture_path_traversal_rejected — real fixture-path validator
     env = core.run("../etc/passwd", mock=True, fixtures_dir="fixtures")
     rows.append(
         _envelope_to_row(
-            "path_traversal_rejected (fixture slug ..)",
+            "fixture_path_traversal_rejected (fixture slug ..)",
             env,
-            "path_traversal_rejected",
+            "fixture_path_traversal_rejected",
             "real-stack-mock",
         )
     )

--- a/tests/test_core_orchestrator.py
+++ b/tests/test_core_orchestrator.py
@@ -239,7 +239,7 @@ def test_orchestrator_graceful_partial_on_missing_fixture() -> None:
     provider_error = env.provenance["site_text_trafilatura"].error
     assert provider_error is not None
     assert "fixture" in provider_error
-    assert env.error.code in {"no_provider_succeeded", "path_traversal_rejected"}
+    assert env.error.code in {"no_provider_succeeded", "fixture_path_traversal_rejected"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_envelope_error_codes.py
+++ b/tests/test_envelope_error_codes.py
@@ -101,15 +101,15 @@ def test_blocked_by_antibot_code_from_robots_block() -> None:
     assert _run_with_error("blocked_by_robots") == "blocked_by_antibot"
 
 
-def test_path_traversal_rejected_code_from_escape_error() -> None:
+def test_fixture_path_traversal_rejected_code_from_escape_error() -> None:
     assert (
         _run_with_error("fixture path escapes fixtures_dir: /etc/passwd")
-        == "path_traversal_rejected"
+        == "fixture_path_traversal_rejected"
     )
 
 
-def test_path_traversal_rejected_code_from_invalid_slug() -> None:
-    assert _run_with_error("invalid fixture slug: '../'") == "path_traversal_rejected"
+def test_fixture_path_traversal_rejected_code_from_invalid_slug() -> None:
+    assert _run_with_error("invalid fixture slug: '../'") == "fixture_path_traversal_rejected"
 
 
 def test_response_too_large_code_from_cap_error() -> None:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -58,19 +58,22 @@ def test_top_level_literal_aliases_expose_expected_members() -> None:
     assert "not_configured" in get_args(ProviderStatus)
     assert "press" in get_args(MentionKind)
     assert "award" in get_args(MentionKind)
-    # Every v0.3 error code must stay re-exported. ``empty_response`` is
-    # the v0.3 addition — COX-44 / #79.
+    # Every v0.4 error code must stay re-exported. ``fixture_path_traversal_rejected``
+    # is the v0.4 rename of ``path_traversal_rejected`` — COX-50 / #87.
     for code in (
         "ssrf_rejected",
         "network_timeout",
         "blocked_by_antibot",
-        "path_traversal_rejected",
+        "fixture_path_traversal_rejected",
         "response_too_large",
         "no_provider_succeeded",
         "misconfigured_provider",
         "empty_response",
+        "cache_corrupted",
     ):
         assert code in get_args(EnvelopeErrorCode), code
+    # Old name must not leak back in — consumers must switch to the new code.
+    assert "path_traversal_rejected" not in get_args(EnvelopeErrorCode)
 
 
 def test_package_version_is_current() -> None:


### PR DESCRIPTION
## Summary
- Rename the public `EnvelopeError.code` from `path_traversal_rejected` to `fixture_path_traversal_rejected` so the code name matches its actual `--mock` fixture-path scope.
- Bump `SCHEMA_VERSION` and the envelope `schema_version` literal to `0.4.0`, then regenerate fixture expectations and update contract tests to pin the new code.
- Refresh SPEC/SCHEMA/SKILL/README/CHANGELOG and the error-code harness to document the rename, the `--mock`-only caveat, and the reconciled pre-1.0 closed-set versioning rule.

Closes #87

## Commits
- `e145a3e` — `feat(schema)!: rename path_traversal_rejected → fixture_path_traversal_rejected + bump schema_version 0.4.0`
- `e14c73e` — `chore(fixtures): bump expected schema_version to 0.4.0`
- `bb3c3dc` — `docs: refresh SPEC/SCHEMA/SKILL/README/CHANGELOG for v0.4.0 rename`
- `d2fe764` — `docs: reconcile closed-set versioning rule across schema.py + SCHEMA.md + SPEC.md`

## Acceptance (from #87 thread)
- [x] `path_traversal_rejected` renamed to `fixture_path_traversal_rejected` (rename option chosen in the issue thread)
- [x] `SCHEMA_VERSION` bumped `0.3.0` → `0.4.0`
- [x] `_classify_error_code` emits the new code
- [x] CHANGELOG `[Unreleased]` BREAKING section documents the rename and migration
- [ ] URL-path traversal guard — deferred by the agreed thread scope; open a follow-up issue if partner validation needs live-URL `../` protection

## Test plan
- [x] `ruff format --check .` clean (reported by branch-author)
- [x] `ruff check .` clean (reported by branch-author)
- [x] `mypy companyctx tests` has 3 unrelated pre-existing `arg-type` failures in `tests/test_reviews_google_places.py`, confirmed present on `main` (reported by branch-author)
- [x] `pytest -q` — 323 passed (reported by branch-author)
- [x] Behavior-specific checks updated: `tests/test_envelope_error_codes.py`, `tests/test_public_api.py`, `tests/test_envelope_schema.py`, and fixture `expected.json` snapshots pin the renamed code and `schema_version: "0.4.0"`

## Breaking changes
- `BREAKING CHANGE:` consumers must switch any branch logic matching `error.code == "path_traversal_rejected"` to `"fixture_path_traversal_rejected"`; envelopes now advertise `schema_version: "0.4.0"`. URL-path traversal remains out of scope in this PR.
