### PR TITLE
fix(classify): NXDOMAIN routes to no_provider_succeeded (COX-49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,20 @@ agents don't re-litigate the design.
   `07-inbound-webhook-enrichment/main.py`, and `08-support-ticket-context.py`
   run clean from any CWD.
 
+### Fixed
+
+- **NXDOMAIN / unresolvable hostnames no longer classify as
+  `ssrf_rejected`** (COX-49 / #86). The SSRF pre-flight now raises a
+  distinct `DNSResolutionError` (subclass of `UnsafeURLError`) when DNS
+  resolution produces no A-records, and providers surface it with a
+  `dns_resolve_failure:` prefix instead of the generic `unsafe_url:`.
+  The envelope classifier routes `dns_resolve_failure` to
+  `no_provider_succeeded`, so `companyctx fetch this-does-not-exist.example`
+  now returns `error.code: "no_provider_succeeded"` — matching agents'
+  branch-on-code expectation for "the site is just unreachable." Top-level
+  `status` is unchanged (still `partial` / `degraded`); this is a
+  code-bucket honesty fix, not a schema change.
+
 ## [0.2.0] — 2026-04-22
 
 ### Changed — BREAKING (envelope schema)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,9 +188,13 @@ agents don't re-litigate the design.
   The envelope classifier routes `dns_resolve_failure` to
   `no_provider_succeeded`, so `companyctx fetch this-does-not-exist.example`
   now returns `error.code: "no_provider_succeeded"` — matching agents'
-  branch-on-code expectation for "the site is just unreachable." Top-level
-  `status` is unchanged (still `partial` / `degraded`); this is a
-  code-bucket honesty fix, not a schema change.
+  branch-on-code expectation for "the site is just unreachable." The
+  envelope's `error.suggestion` also gets a DNS-specific line
+  ("hostname did not resolve in DNS; verify the site spelling") instead
+  of the default "configure a smart-proxy" remediation, since no proxy
+  resolves NXDOMAIN on the user's behalf. Top-level `status` is unchanged
+  (still `partial` / `degraded`); this is a code-bucket + suggestion
+  honesty fix, not a schema change.
 
 ## [0.2.0] — 2026-04-22
 

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -81,6 +81,13 @@ EMPTY_RESPONSE_SUGGESTION = (
     "site returned HTTP 200 with effectively no content; "
     "try --ignore-robots or check with a browser"
 )
+# DNS-failure remediation: pointing the user at a smart-proxy is misleading
+# when the hostname simply does not exist — no proxy will resolve NXDOMAIN
+# back into a valid A-record. Keep the suggestion scoped to the actual
+# remediation: check the name, try again later if transient.
+DNS_RESOLVE_FAILURE_SUGGESTION = (
+    "hostname did not resolve in DNS; verify the site spelling (or retry later if transient)"
+)
 
 
 def run(
@@ -573,7 +580,7 @@ def _build_envelope_error(
     return EnvelopeError(
         code=code,
         message=message,
-        suggestion=_suggestion_for(code, failure_status=failure_status),
+        suggestion=_suggestion_for(code, failure_status=failure_status, message=message),
     )
 
 
@@ -581,6 +588,7 @@ def _suggestion_for(
     code: EnvelopeErrorCode,
     *,
     failure_status: ProviderStatus | None = None,
+    message: str | None = None,
 ) -> str:
     """Per-code actionable suggestion.
 
@@ -589,13 +597,21 @@ def _suggestion_for(
     nothing. ``misconfigured_provider`` routes to a provider-agnostic
     hint ("configure the missing provider's env key") since the actual
     env-var name already lives in ``error.message`` (the provider's own
-    error string is preserved verbatim). Everything else falls back to
-    the smart-proxy suggestion that applies to Attempt-1 blocks.
+    error string is preserved verbatim). DNS failure (COX-49) gets its
+    own line too — a smart-proxy cannot resolve an NXDOMAIN on the user's
+    behalf. Everything else falls back to the smart-proxy suggestion that
+    applies to Attempt-1 blocks.
     """
     if code == "empty_response":
         return EMPTY_RESPONSE_SUGGESTION
     if code == "misconfigured_provider" or failure_status == "not_configured":
         return GENERIC_SUGGESTION
+    if (
+        code == "no_provider_succeeded"
+        and message is not None
+        and "dns_resolve_failure" in message.lower()
+    ):
+        return DNS_RESOLVE_FAILURE_SUGGESTION
     return SMART_PROXY_SUGGESTION
 
 

--- a/companyctx/core.py
+++ b/companyctx/core.py
@@ -615,6 +615,11 @@ def _classify_error_code(
     """
     del envelope_status  # Reserved for future per-status heuristics.
     lower = message.lower()
+    # An unresolvable hostname is not an SSRF attempt (COX-49). Providers
+    # emit ``dns_resolve_failure:`` for this case so it routes to the generic
+    # no-provider-succeeded bucket rather than the SSRF pre-flight bucket.
+    if "dns_resolve_failure" in lower:
+        return "no_provider_succeeded"
     if "unsafe_url" in lower or "unsupported scheme" in lower or "invalid site" in lower:
         return "ssrf_rejected"
     if "fixture path escapes" in lower or "fixture file escapes" in lower:

--- a/companyctx/providers/site_text_trafilatura.py
+++ b/companyctx/providers/site_text_trafilatura.py
@@ -40,6 +40,7 @@ from companyctx.schema import ProviderRunMetadata, SiteSignals
 from companyctx.security import (
     MAX_REDIRECTS,
     MAX_RESPONSE_BYTES,
+    DNSResolutionError,
     UnsafeURLError,
     validate_public_http_url,
 )
@@ -247,6 +248,8 @@ def _ensure_safe_for_fetch(url: str, ctx: FetchContext) -> None:
     """
     try:
         validate_public_http_url(url)
+    except DNSResolutionError as exc:
+        raise _BlockedError(f"dns_resolve_failure: {exc}") from exc
     except UnsafeURLError as exc:
         raise _BlockedError(f"unsafe_url: {exc}") from exc
     if not ctx.ignore_robots and not is_allowed(url, user_agent=ctx.user_agent):

--- a/companyctx/providers/smart_proxy_http.py
+++ b/companyctx/providers/smart_proxy_http.py
@@ -38,6 +38,7 @@ from companyctx.schema import ProviderRunMetadata
 from companyctx.security import (
     MAX_REDIRECTS,
     MAX_RESPONSE_BYTES,
+    DNSResolutionError,
     UnsafeURLError,
     validate_public_http_url,
 )
@@ -197,6 +198,8 @@ def _ensure_safe_for_fetch(url: str, ctx: FetchContext) -> None:
     """
     try:
         validate_public_http_url(url)
+    except DNSResolutionError as exc:
+        raise _ProxyError(f"dns_resolve_failure: {exc}") from exc
     except UnsafeURLError as exc:
         raise _ProxyError(f"unsafe_url: {exc}") from exc
     if not ctx.ignore_robots and not is_allowed(url, user_agent=ctx.user_agent):

--- a/companyctx/security.py
+++ b/companyctx/security.py
@@ -39,6 +39,17 @@ class UnsafeURLError(ValueError):
     """Raised when a URL fails the public-HTTP guardrail."""
 
 
+class DNSResolutionError(UnsafeURLError):
+    """Raised when a hostname fails to resolve (NXDOMAIN, no-A-record, etc.).
+
+    Distinct from :class:`UnsafeURLError` so callers can route DNS-failure to
+    a non-SSRF envelope error code (``no_provider_succeeded``). Inherits from
+    :class:`UnsafeURLError` to preserve existing ``except UnsafeURLError``
+    fall-open branches (robots pre-flight) which treat any validation failure
+    identically.
+    """
+
+
 def validate_public_http_url(url: str) -> str:
     """Reject URLs that point at non-public or non-HTTP destinations.
 
@@ -86,7 +97,7 @@ def _resolve_all(host: str) -> list[str]:
     try:
         infos = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
     except OSError as exc:
-        raise UnsafeURLError(f"DNS resolution failed for {host}: {exc}") from exc
+        raise DNSResolutionError(f"DNS resolution failed for {host}: {exc}") from exc
     seen: set[str] = set()
     addrs: list[str] = []
     for info in infos:
@@ -101,7 +112,7 @@ def _resolve_all(host: str) -> list[str]:
             seen.add(ip)
             addrs.append(ip)
     if not addrs:
-        raise UnsafeURLError(f"no addresses for {host}")
+        raise DNSResolutionError(f"no addresses for {host}")
     return addrs
 
 
@@ -119,6 +130,7 @@ __all__ = [
     "ALLOWED_SCHEMES",
     "MAX_REDIRECTS",
     "MAX_RESPONSE_BYTES",
+    "DNSResolutionError",
     "UnsafeURLError",
     "validate_public_http_url",
 ]

--- a/scripts/run-shape-probe.py
+++ b/scripts/run-shape-probe.py
@@ -70,6 +70,7 @@ from companyctx.robots import is_allowed
 from companyctx.security import (
     MAX_REDIRECTS,
     MAX_RESPONSE_BYTES,
+    DNSResolutionError,
     UnsafeURLError,
     validate_public_http_url,
 )
@@ -186,6 +187,8 @@ def _stealth_fetch_guarded(url: str, timeout_s: float) -> tuple[int, str, int, i
     while True:
         try:
             validate_public_http_url(current)
+        except DNSResolutionError as exc:
+            raise _ProbeFetchError(f"dns_resolve_failure: {exc}") from exc
         except UnsafeURLError as exc:
             raise _ProbeFetchError(f"unsafe_url: {exc}") from exc
         try:
@@ -279,7 +282,9 @@ def probe_one(
         row["elapsed_ms"] = int((time.monotonic() - t0) * 1000)
         reason = str(exc)
         row["error"] = reason
-        if reason.startswith("unsafe_url"):
+        if reason.startswith("dns_resolve_failure"):
+            row["outcome"] = "dns_resolve_failure"
+        elif reason.startswith("unsafe_url"):
             row["outcome"] = "unsafe_url"
         elif reason.startswith("blocked_by_antibot"):
             row["outcome"] = "blocked_by_antibot"

--- a/tests/test_envelope_error_codes.py
+++ b/tests/test_envelope_error_codes.py
@@ -128,5 +128,19 @@ def test_no_provider_succeeded_code_for_unclassified_reason() -> None:
     assert _run_with_error("something we do not recognize") == "no_provider_succeeded"
 
 
+def test_dns_resolve_failure_routes_to_no_provider_succeeded() -> None:
+    """An unresolvable hostname must NOT classify as SSRF (COX-49).
+
+    Providers emit ``dns_resolve_failure: ...`` for NXDOMAIN / no-A-record.
+    The classifier routes that to ``no_provider_succeeded``; the generic
+    ``unsafe_url`` substring check (which lands on ``ssrf_rejected``) must
+    not win first.
+    """
+    assert (
+        _run_with_error("dns_resolve_failure: DNS resolution failed for nope.example")
+        == "no_provider_succeeded"
+    )
+
+
 def test_empty_response_code_from_provider_error_string() -> None:
     assert _run_with_error("empty_response") == "empty_response"

--- a/tests/test_envelope_error_codes.py
+++ b/tests/test_envelope_error_codes.py
@@ -142,5 +142,29 @@ def test_dns_resolve_failure_routes_to_no_provider_succeeded() -> None:
     )
 
 
+def test_dns_resolve_failure_gets_dns_specific_suggestion() -> None:
+    """DNS failure routes to a DNS-specific suggestion, not the smart-proxy one.
+
+    Regression for COX-49 review feedback: ``no_provider_succeeded`` falls
+    back to ``SMART_PROXY_SUGGESTION`` by default, but a smart-proxy cannot
+    resolve NXDOMAIN. The classifier's message-aware suggestion dispatch
+    must surface the DNS-specific remediation instead.
+    """
+    provider = _make_failing_provider(
+        slug="errorprobe",
+        error="dns_resolve_failure: DNS resolution failed for nope.example",
+    )
+    env = core.run(
+        "probe.example",
+        mock=True,
+        providers=_reg(errorprobe=provider),
+        fetched_at=FIXED_WHEN,
+    )
+    assert env.error is not None
+    assert env.error.code == "no_provider_succeeded"
+    assert env.error.suggestion == core.DNS_RESOLVE_FAILURE_SUGGESTION
+    assert env.error.suggestion != core.SMART_PROXY_SUGGESTION
+
+
 def test_empty_response_code_from_provider_error_string() -> None:
     assert _run_with_error("empty_response") == "empty_response"

--- a/tests/test_security_url.py
+++ b/tests/test_security_url.py
@@ -27,6 +27,7 @@ from companyctx.providers.site_text_trafilatura import (
     _stealth_fetch,
 )
 from companyctx.security import (
+    DNSResolutionError,
     UnsafeURLError,
     validate_public_http_url,
 )
@@ -125,6 +126,56 @@ def test_dns_rebinding_is_caught_on_resolve(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr("companyctx.security.socket.getaddrinfo", fake_getaddrinfo)
     with pytest.raises(UnsafeURLError, match="non-public"):
         validate_public_http_url("http://rebind.example.com/")
+
+
+def test_dns_failure_raises_dns_resolution_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NXDOMAIN-style resolution failure raises :class:`DNSResolutionError`.
+
+    Regression guard for COX-49: an unresolvable host must surface a
+    distinct exception type so downstream envelope classification can route
+    it to ``no_provider_succeeded`` instead of ``ssrf_rejected``.
+    :class:`DNSResolutionError` subclasses :class:`UnsafeURLError` so
+    pre-existing ``except UnsafeURLError`` fall-open branches (robots) stay
+    correct.
+    """
+
+    def fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+        raise OSError("[Errno 8] nodename nor servname provided, or not known")
+
+    monkeypatch.setattr("companyctx.security.socket.getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(DNSResolutionError, match="DNS resolution failed"):
+        validate_public_http_url("http://this-does-not-exist.example/")
+
+
+def test_dns_failure_is_subclass_of_unsafe_url_error() -> None:
+    """Preserve the ``except UnsafeURLError`` contract for existing callers."""
+    assert issubclass(DNSResolutionError, UnsafeURLError)
+
+
+def test_stealth_fetch_emits_dns_resolve_failure_prefix_on_nxdomain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Provider wrapper distinguishes DNS failure from SSRF rejection (COX-49).
+
+    The zero-key provider must prefix DNS failures with
+    ``dns_resolve_failure:`` so the orchestrator's envelope classifier
+    routes them to ``no_provider_succeeded`` rather than ``ssrf_rejected``.
+    """
+    called = {"count": 0}
+
+    def fake_get(*args: Any, **kwargs: Any) -> Any:
+        called["count"] += 1
+        raise AssertionError("network must not be reached for NXDOMAIN input")
+
+    def fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+        raise OSError("[Errno 8] nodename nor servname provided, or not known")
+
+    monkeypatch.setattr("companyctx.security.socket.getaddrinfo", fake_getaddrinfo)
+    monkeypatch.setattr("companyctx.providers.site_text_trafilatura.requests.get", fake_get)
+    ctx = FetchContext(user_agent=UA, timeout_s=1.0, ignore_robots=True)
+    with pytest.raises(_BlockedError, match=r"^dns_resolve_failure:"):
+        _stealth_fetch("http://this-does-not-exist-abc123xyz.example/", ctx)
+    assert called["count"] == 0
 
 
 def test_stealth_fetch_rejects_ssrf_before_network(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_shape_probe.py
+++ b/tests/test_shape_probe.py
@@ -1,0 +1,57 @@
+"""Regression coverage for the shape-probe harness's SSRF pre-flight (COX-49).
+
+The research harness at ``scripts/run-shape-probe.py`` reuses the same
+SSRF guardrails the zero-key provider applies. When ``security.py``
+introduced :class:`DNSResolutionError` (COX-49), the harness's wrapper
+was updated to catch it before the generic :class:`UnsafeURLError` so
+an unresolvable hostname buckets as ``dns_resolve_failure`` in the
+probe report instead of ``unsafe_url``. This test pins that parity
+directly against the script rather than the in-tree provider, since
+the harness runs against the same error strings for its outcome
+classification.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "run-shape-probe.py"
+
+
+def _load_shape_probe() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("shape_probe", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_shape_probe_emits_dns_resolve_failure_prefix_on_nxdomain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NXDOMAIN pre-flight in the probe harness raises a ``dns_resolve_failure:`` error.
+
+    Keeps the probe's outcome bucketing honest: the ``dns_resolve_failure``
+    bucket in ``scripts/run-shape-probe.py`` is gated on the error-string
+    prefix, so the harness must emit the distinct prefix (not
+    ``unsafe_url:``) when DNS resolution fails.
+    """
+    module = _load_shape_probe()
+
+    def _fake_getaddrinfo(host: str, *args: Any, **kwargs: Any) -> list[Any]:
+        raise OSError("[Errno 8] nodename nor servname provided, or not known")
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("network must not be reached for NXDOMAIN input")
+
+    monkeypatch.setattr("companyctx.security.socket.getaddrinfo", _fake_getaddrinfo)
+    monkeypatch.setattr(module.requests, "get", _boom)
+
+    with pytest.raises(module._ProbeFetchError, match=r"^dns_resolve_failure:"):
+        module._stealth_fetch_guarded("http://this-does-not-exist-abc123xyz.example/", 1.0)

--- a/tests/test_smart_proxy_http.py
+++ b/tests/test_smart_proxy_http.py
@@ -744,6 +744,38 @@ def test_smart_proxy_rejects_non_http_scheme(monkeypatch: pytest.MonkeyPatch) ->
     assert "unsafe_url" in meta.error
 
 
+def test_smart_proxy_emits_dns_resolve_failure_prefix_on_nxdomain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NXDOMAIN pre-flight → ``dns_resolve_failure:`` row, proxy never contacted (COX-49).
+
+    Parity with ``site_text_trafilatura``: the smart-proxy wrapper must
+    catch :class:`DNSResolutionError` before the generic
+    :class:`UnsafeURLError` path so downstream envelope classification
+    routes the failure to ``no_provider_succeeded`` instead of
+    ``ssrf_rejected``.
+    """
+    monkeypatch.setenv(ENV_URL, "http://user:pass@host:7777")
+
+    def _fake_getaddrinfo(host: str, *args: object, **kwargs: object) -> list[object]:
+        raise OSError("[Errno 8] nodename nor servname provided, or not known")
+
+    def _boom(*args: object, **kwargs: object) -> _FakeResponse:
+        raise AssertionError("proxy must not fire for unresolvable host")
+
+    monkeypatch.setattr("companyctx.security.socket.getaddrinfo", _fake_getaddrinfo)
+    monkeypatch.setattr("companyctx.providers.smart_proxy_http.requests.get", _boom)
+
+    body, meta = SmartProxyHttpProvider().fetch(
+        "http://this-does-not-exist-abc123xyz.example/", ctx=_ctx()
+    )
+    assert body is None
+    assert meta.status == "failed"
+    assert meta.error is not None
+    assert meta.error.startswith("dns_resolve_failure:")
+    assert "unsafe_url" not in meta.error
+
+
 def test_smart_proxy_rejects_metadata_host(monkeypatch: pytest.MonkeyPatch) -> None:
     """Cloud-metadata hostnames are refused before egress through the proxy."""
     monkeypatch.setenv(ENV_URL, "http://user:pass@host:7777")


### PR DESCRIPTION
## Summary
- NXDOMAIN / unresolvable hostnames no longer classify as `ssrf_rejected`. The SSRF pre-flight raises a distinct `DNSResolutionError` (subclass of `UnsafeURLError` so existing `except UnsafeURLError` fall-open branches stay correct), providers surface it with a `dns_resolve_failure:` prefix, and the envelope classifier routes that to `no_provider_succeeded`.
- `error.suggestion` gets a DNS-specific line ("hostname did not resolve in DNS; verify the site spelling") instead of the default smart-proxy hint — no proxy resolves NXDOMAIN on the user's behalf.
- Schema-stable: no new `EnvelopeErrorCode` Literal. Top-level `status` is unchanged (still `partial` / `degraded`); this is a code-bucket + suggestion honesty fix.
- Parity updates in `smart_proxy_http` and `scripts/run-shape-probe.py` so every SSRF pre-flight site emits the split prefix.

## Commits
- `7ea17dc` — fix(classify): NXDOMAIN routes to no_provider_succeeded (COX-49)
- `deb462d` — test(security): cover DNS-failure classification (COX-49)
- `38ca290` — docs(changelog): note COX-49 NXDOMAIN classification fix
- `c9e4d31` — fix(classify): DNS-specific suggestion for NXDOMAIN (COX-49 review)
- `72d738f` — test(security): parity coverage for smart-proxy + shape-probe (COX-49 review)
- `60b37ca` — docs(changelog): note DNS-specific suggestion in COX-49 entry

## Acceptance (from #86)
- [x] `security.py` / SSRF pre-flight: distinguish DNS failure from IP-private-range rejection by error-string prefix (via `DNSResolutionError` subclass).
- [x] `core._classify_error_code`: route DNS failure to `no_provider_succeeded` (no new `dns_unresolvable` code — schema bump deferred to v0.4 per the Apr 22 comment).
- [x] Test case: unresolvable domain → `error.code: "no_provider_succeeded"`, not `"ssrf_rejected"`.
- [x] Review follow-up: DNS-specific `error.suggestion`; parity tests for `smart_proxy_http` and `run-shape-probe`.

## Test plan
- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy companyctx` clean (17 source files). `mypy companyctx tests` surfaces 3 pre-existing errors in `tests/test_reviews_google_places.py` from main — not introduced here; CI only gates on `mypy companyctx`.
- [x] `pytest -q` — 330 tests passed (up from 327, +3 new regression tests)
- [x] Live reproducer: `run("this-does-not-exist-abc123xyz.example")` now returns `status: partial`, `error.code: no_provider_succeeded`, DNS-specific suggestion text.

Closes #86.