### PR TITLE
docs: rephrase tagline around "company context" (Closes #34)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/anthropics/claude-code/main/schemas/plugin.json",
   "name": "companyctx",
   "version": "0.1.0",
-  "description": "Deterministic B2B context router. Zero keys. Schema-locked JSON for agent pipelines.",
+  "description": "Deterministic B2B company context router. Zero keys. Schema-locked JSON for agent pipelines.",
   "homepage": "https://github.com/dmthepm/companyctx",
   "license": "MIT",
   "tags": ["cli", "b2b", "context", "agent", "deterministic"],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # companyctx
 
-**Deterministic B2B context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust.**
+**The deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust.**
 
 ```bash
 pipx install companyctx   # v0.2.0 on PyPI — schema_version field + structured errors

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,11 @@
 # SKILL.md — companyctx
 
-**Purpose.** Deterministic B2B context router. One site in,
-schema-locked JSON envelope out. Zero keys on the default path.
+**Purpose:** Extract deterministic, schema-locked company context
+(tech stack, reviews, core offerings) from any B2B domain. One site in,
+one JSON envelope out. Zero keys on the default path.
+
+`companyctx = company context.` The product packages the context of a
+company so an agent can reason about it, rather than reading raw HTML.
 
 **Commands.**
 

--- a/companyctx/__init__.py
+++ b/companyctx/__init__.py
@@ -1,4 +1,4 @@
-"""companyctx — deterministic B2B context router. Zero keys. Schema-locked JSON."""
+"""companyctx — deterministic B2B company context router. Zero keys. Schema-locked JSON."""
 
 from __future__ import annotations
 

--- a/companyctx/cli.py
+++ b/companyctx/cli.py
@@ -40,7 +40,7 @@ from companyctx.schema import SCHEMA_VERSION, Envelope
 
 app = typer.Typer(
     name="companyctx",
-    help="Deterministic B2B context router. Zero keys. Schema-locked JSON.",
+    help="Deterministic B2B company context router. Zero keys. Schema-locked JSON.",
     no_args_is_help=True,
     add_completion=False,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "companyctx"
 version = "0.3.0"
-description = "Deterministic B2B context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust."
+description = "Deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

- Establishes `companyctx = company context` as the semantic anchor across every user-facing description surface.
- README subtitle, SKILL.md Purpose line, and the GitHub repo description (updated out-of-band via `gh repo edit`) now use the exact copy requested in #34.
- Aligns the tagline on the other surfaces that feed that same one-liner to users — `pyproject.toml` (PyPI), `companyctx/cli.py` Typer help (`--help`), `companyctx/__init__.py` docstring, `.claude-plugin/plugin.json` — so README / PyPI / CLI / plugin catalog agree.
- Tagline-only rephrase. Zero behavior change, zero code paths touched.

## Commits

- `496e8b4` — docs: rephrase tagline around "company context" (Closes #34)

## Acceptance (from #34)

- [x] GitHub repo description set to "Deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust." (verified via `gh repo view`).
- [x] README.md subtitle set to "**The deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust.**" verbatim.
- [x] SKILL.md first line set to "**Purpose:** Extract deterministic, schema-locked company context (tech stack, reviews, core offerings) from any B2B domain." verbatim, with a one-line `companyctx = company context` anchor underneath to seed the semantic link for agents reading the skill.

## Test plan

- [x] `ruff format --check .` — 45 files clean.
- [x] `ruff check .` — all checks passed.
- [x] `mypy companyctx` — clean (matches CI scope across the 3.10 / 3.11 / 3.12 matrix).
- [ ] `mypy companyctx tests` — **3 pre-existing errors** in `tests/test_reviews_google_places.py:488,499,530` (`dict[str, type[object]]` vs `Mapping[str, type[ProviderBase]]`). Confirmed present on `main` before this branch; not introduced here and not CI-gated. Tracked in #99.
- [x] `pytest -q` — 323 tests passed.

Docs-only: no behavior-specific checks (`--mock` determinism, fixture byte-identity) apply.