### PR TITLE
ci: wheel-install smoke test (Closes #77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,3 +99,112 @@ jobs:
 
       - name: pyroma (package metadata health, threshold 9/10)
         run: pyroma -n 9 .
+
+  wheel-install-smoke:
+    # Release-path smoke test. The lint-type-test matrix runs against an
+    # editable install (``pip install -e .``), which can't catch packaging
+    # drift — a missing ``py.typed`` in the built wheel, a stale
+    # ``[tool.setuptools.package-data]`` entry, or an entry-point group that
+    # only registers under editable mode. This job builds the wheel + sdist
+    # the way PyPI will consume them, installs the wheel into a clean venv
+    # (no repo sources on ``sys.path``), and runs the user-facing smoke
+    # commands end-to-end. See docs/OSS-HYGIENE.md §6 Reproducibility.
+    #
+    # Single Python version — wheel packaging is pure-Python and doesn't
+    # vary across 3.10/3.11/3.12 enough to justify matrixing. We pick 3.12
+    # (latest supported target). Multi-Python matrix is intentionally
+    # out-of-scope; trusted-publisher validates the upload itself on PyPI.
+    name: wheel-install-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build sdist + wheel
+        run: python -m build
+
+      - name: Verify py.typed shipped in wheel
+        # The editable install test suite can't catch a missing py.typed —
+        # it reads straight from the source tree. A wheel without py.typed
+        # silently degrades downstream mypy to Any. Fail loudly here.
+        run: |
+          wheel=$(ls dist/companyctx-*.whl | head -n1)
+          echo "inspecting $wheel"
+          python -m zipfile -l "$wheel"
+          python -m zipfile -l "$wheel" | grep -E '(^|/)companyctx/py\.typed([[:space:]]|$)' \
+            || { echo "::error::py.typed missing from wheel"; exit 1; }
+
+      - name: Create fresh venv and install the wheel
+        # Fresh venv means no repo sources on sys.path — a genuine
+        # release-path install. ``pip install <wheel>`` (not ``-e``) is
+        # the point of this job; an editable install can't catch
+        # package-data drift.
+        run: |
+          python -m venv .venv-smoke
+          .venv-smoke/bin/pip install --upgrade pip
+          .venv-smoke/bin/pip install ./dist/companyctx-*.whl
+
+      - name: Smoke — companyctx --version
+        # Exit 0 and emits the current version string. Catches entry-point
+        # registration drift (``[project.scripts]`` stale).
+        run: |
+          out=$(.venv-smoke/bin/companyctx --version)
+          echo "$out"
+          case "$out" in
+            "companyctx 0.3.0") ;;
+            *) echo "::error::unexpected --version output: $out"; exit 1 ;;
+          esac
+
+      - name: Smoke — companyctx schema (valid JSON Schema)
+        # Stamps ``$schema`` (Draft 2020-12) — catches Pydantic upgrades
+        # that change the schema shape, and catches missing
+        # ``companyctx.schema`` import paths in the wheel.
+        run: |
+          .venv-smoke/bin/companyctx schema > schema.json
+          .venv-smoke/bin/python -c '
+          import json
+          doc = json.load(open("schema.json"))
+          assert "$schema" in doc, "missing $schema key"
+          assert doc["$schema"].startswith("https://json-schema.org/draft/2020-12"), doc["$schema"]
+          assert "properties" in doc, "missing properties"
+          assert "status" in doc["properties"], "envelope missing status field"
+          '
+
+      - name: Smoke — companyctx providers list (non-empty)
+        # Catches entry-point group registration drift — if the
+        # ``[project.entry-points."companyctx.providers"]`` table doesn't
+        # land in the wheel, this returns zero providers.
+        run: |
+          .venv-smoke/bin/companyctx providers list --json > providers.json
+          cat providers.json
+          .venv-smoke/bin/python -c '
+          import json
+          rows = json.load(open("providers.json"))
+          assert isinstance(rows, list) and rows, "no providers registered"
+          assert any(r.get("slug") == "site_text_trafilatura" for r in rows), rows
+          '
+
+      - name: Smoke — companyctx fetch (mock, JSON envelope)
+        # End-to-end run through the deterministic waterfall against a
+        # pinned fixture. Verifies the envelope shape, migrations data,
+        # and provider plumbing all survived the wheel boundary.
+        run: |
+          .venv-smoke/bin/companyctx fetch acme-bakery.example \
+            --mock --json --no-cache > envelope.json
+          .venv-smoke/bin/python -c '
+          import json
+          env = json.load(open("envelope.json"))
+          assert env["status"] in {"ok", "partial", "degraded"}, env["status"]
+          assert "data" in env and "provenance" in env, env.keys()
+          assert "schema_version" in env, env.keys()
+          '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,15 +155,24 @@ jobs:
           .venv-smoke/bin/pip install ./dist/companyctx-*.whl
 
       - name: Smoke — companyctx --version
-        # Exit 0 and emits the current version string. Catches entry-point
-        # registration drift (``[project.scripts]`` stale).
+        # Exit 0 and emits ``companyctx <version>`` where <version> matches
+        # the installed distribution metadata. Catches entry-point
+        # registration drift (``[project.scripts]`` stale) and version
+        # skew between ``companyctx.__version__`` and the wheel metadata.
+        # The expected string is derived from ``importlib.metadata`` inside
+        # the smoke venv so a routine version bump doesn't require a CI
+        # edit — the gate checks that the CLI agrees with the wheel it
+        # was installed from, not that it hits a literal.
         run: |
+          expected="companyctx $(.venv-smoke/bin/python -c \
+            'from importlib.metadata import version; print(version("companyctx"))')"
           out=$(.venv-smoke/bin/companyctx --version)
-          echo "$out"
-          case "$out" in
-            "companyctx 0.3.0") ;;
-            *) echo "::error::unexpected --version output: $out"; exit 1 ;;
-          esac
+          echo "expected=$expected"
+          echo "actual=  $out"
+          if [ "$out" != "$expected" ]; then
+            echo "::error::--version output ($out) does not match installed dist metadata ($expected)"
+            exit 1
+          fi
 
       - name: Smoke — companyctx schema (valid JSON Schema)
         # Stamps ``$schema`` (Draft 2020-12) — catches Pydantic upgrades

--- a/docs/OSS-HYGIENE.md
+++ b/docs/OSS-HYGIENE.md
@@ -118,7 +118,14 @@ byte-identical `--mock` output across runs.*
   linting on `main` — either pinned to a specific version or bounded
   with a compatible-release operator (`~=`). Fixtures are deterministic
   and re-generating them produces byte-identical output modulo
-  `fetched_at`.
+  `fetched_at`. A `wheel-install-smoke` job (same workflow, runs on
+  `push` + `pull_request`) exercises the release path end-to-end:
+  `python -m build` produces sdist + wheel, the wheel installs into a
+  fresh venv (no repo sources on `sys.path`), and the user-facing smoke
+  commands (`--version`, `schema`, `providers list`, `fetch --mock`)
+  run against it. Catches packaging drift the editable-install matrix
+  can't see — a missing `py.typed`, a stale `[tool.setuptools.package-data]`
+  entry, or an entry-point group that only registers under `-e`.
 - **Fail.** CI uses `python-version: 3.x` (floats). `ruff>=0.4` in dev
   deps lets a major-bump release of ruff silently change lint rules on
   the next install. A fixture regenerator is non-deterministic (random


### PR DESCRIPTION
## Summary
- New `wheel-install-smoke` job in `.github/workflows/ci.yml`: builds sdist + wheel via `python -m build`, installs the wheel into a fresh venv (no repo sources on `sys.path`), then runs the user-facing smoke commands end-to-end.
- Explicit `py.typed` presence check on the wheel contents — catches packaging drift the editable-install matrix can't see.
- Smoke commands: `--version` (derived from installed dist metadata so the gate doesn't self-expire on version bumps), `schema` (valid Draft 2020-12 JSON Schema), `providers list --json` (non-empty with `site_text_trafilatura` registered), `fetch acme-bakery.example --mock --json` (envelope shape + status).
- Single Python version (3.12). Triggers on `push` to `main` and `pull_request`, same as the existing matrix.
- `docs/OSS-HYGIENE.md` §6 Reproducibility now references the new gate.

## Commits
- `1b2661f — ci: add wheel-install-smoke job (Closes #77)`
- `75ff100 — docs(oss-hygiene): reference wheel-install-smoke in §6 Reproducibility`
- `3552cd9 — ci(wheel-smoke): derive expected version from dist metadata`

## Acceptance (from #77)
- [x] New `wheel-install-smoke` job in `.github/workflows/ci.yml`.
- [x] Runs on `push` + `pull_request`.
- [x] Fails cleanly if `py.typed` is missing from the wheel.
- [x] Fails cleanly if any of the smoke commands exits non-zero.
- [x] Zero-red on the current green main.
- [x] `docs/OSS-HYGIENE.md` §reproducibility references this gate.

## Test plan
- [x] `ruff format --check .` clean
- [x] `ruff check .` clean
- [x] `mypy companyctx` clean (matches the invocation CI uses). `mypy companyctx tests` has 3 pre-existing errors in `tests/test_reviews_google_places.py` present on `main` — unrelated to this change.
- [x] `pytest -q` — 323 passed
- [x] Full wheel-install-smoke flow exercised locally against a freshly built `companyctx-0.3.0-py3-none-any.whl`: version match, schema valid, 3 providers registered, envelope `status=ok` against `acme-bakery.example`