### PR TITLE
chore(release)!: v0.4.0 — FM-7 floor + NXDOMAIN + cache + schema 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,12 @@ All notable changes to `companyctx` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v0.4.0
+## [0.4.0] — 2026-04-23
 
 v0.4.0 bundles the COX-52 FM-7 floor correction, the COX-49 NXDOMAIN
 routing fix, and a schema-version bump that closes the drift the
 v0.3.0 cache merge introduced (the `cache_corrupted` Literal was added
-without bumping `SCHEMA_VERSION`). Package version stays at `0.3.0`
-until the separate release-runbook PR cuts the tag.
+without bumping `SCHEMA_VERSION`).
 
 ### Changed — envelope schema bump (v0.4)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **The deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust.**
 
 ```bash
-pipx install companyctx   # v0.2.0 on PyPI — schema_version field + structured errors
+pipx install companyctx   # v0.4.0 on PyPI — schema_version 0.4.0, SQLite cache, FM-7 floor
 companyctx fetch acme-bakery.com --json
 ```
 
@@ -55,12 +55,12 @@ which is what the `--mock` fixture tree reproduces byte-for-byte.
 
 ## Status
 
-`v0.2.0` is the current release. What's shipped:
+`v0.4.0` is the current release. What's shipped:
 
 - **Envelope contract** — `{schema_version, status, data, provenance, error?}`
   with `status ∈ {ok, partial, degraded}` and a structured `EnvelopeError`
   (`{code, message, suggestion}`) on non-`ok` runs. `extra="forbid"` on every
-  model. See [`docs/SCHEMA.md`](docs/SCHEMA.md).
+  model. `schema_version` Literal is `"0.4.0"`. See [`docs/SCHEMA.md`](docs/SCHEMA.md).
 - **Zero-key Attempt 1** — `site_text_trafilatura` (TLS-impersonated fetch
   via `curl_cffi` + trafilatura extraction). Populates `data.pages.*`
   (`homepage_text`, `about_text`, `services`, `tech_stack`). 20/20 envelope-`ok`
@@ -70,23 +70,35 @@ which is what the `--mock` fixture tree reproduces byte-for-byte.
   proxy). User supplies `COMPANYCTX_SMART_PROXY_URL`; env-unset surfaces as
   `not_configured` with an actionable suggestion rather than a crash. Named-
   vendor adapter lands after the smart-proxy vendor eval (tracking: #63).
+- **SQLite fetch cache (Vertical Memory wiring).** `--from-cache` /
+  `--refresh` / `--no-cache` on `fetch`, plus `cache list` and
+  `cache clear --site X` / `--older-than 7d`. XDG paths via
+  `platformdirs`; schema-versioned migrations. `cache_corrupted` is a
+  first-class `EnvelopeErrorCode`.
+- **FM-7 honesty contract** — `EMPTY_RESPONSE_BYTES` raised from 64 to
+  1024 (COX-52 / #91). HTTP 200 with <1024 UTF-8 bytes of extracted text
+  now surfaces as `status: degraded + error.code: empty_response` instead
+  of silent `ok`.
+- **NXDOMAIN routed to `no_provider_succeeded`** — unresolvable hostnames
+  are dead hosts, not SSRF attempts (COX-49 / #86).
 - **CLI verbs** — `fetch`, `schema` (emits Draft 2020-12 JSON Schema),
-  `validate`, `providers list` (with `--json`, waterfall tier, config
-  status, reason).
+  `validate`, `providers list`, `cache list`, `cache clear` (with
+  `--json` where applicable).
 - **`py.typed` marker + public-API re-exports** — `from companyctx import
   Envelope, EnvelopeError, CompanyContext, ...` works straight off the
   package root; downstream `mypy` sees concrete types.
 
 What's **not** shipped yet and is explicitly deferred (the CLI surface
-rejects these flags with a tracking-issue pointer rather than silently
+rejects these with a tracking-issue pointer rather than silently
 accepting them):
 
-- **SQLite fetch cache** (`--from-cache` / `--refresh` / `--no-cache` /
-  `--config`) — tracked in #9.
-- **`batch <csv>`** — stub, prints an error and exits non-zero.
+- **`batch <csv>`** — stub, prints an error and exits non-zero. Tracked
+  in #9.
+- **`--config <path>` TOML loader** — stub; environment variables and
+  defaults only today. Tracked in #9.
 - **Direct-API (Attempt 3) providers** — Google Places (tracking: #7),
-  Yelp Fusion, YouTube Data, Brave Search (mentions tracking: #58). None
-  registered in v0.2; `data.reviews` / `data.social` / `data.mentions`
+  Yelp Fusion, YouTube Data, Brave Search (mentions tracking: #58). Not
+  registered today; `data.reviews` / `data.social` / `data.mentions`
   stay null on live runs until a direct-API provider lands.
 - **Site-heuristic `signals` provider** — planned alongside the direct-API
   slate; populates `data.signals.copyright_year`, `last_blog_post_at`,
@@ -96,8 +108,10 @@ accepting them):
   step, not here (tracking: #68).
 
 Measured 97% envelope-`ok` rate on a 100-site real-world sample on the
-v0.1 zero-key baseline; post-v0.2 re-measurement tracks under the durability
-rerun (#61). Full breakdown in
+v0.1 zero-key baseline. A 209-site partner-integration re-classification
+against the v0.4 FM-7 floor
+([`research/2026-04-23-cox-52-post-fix-reclassification.md`](research/2026-04-23-cox-52-post-fix-reclassification.md))
+puts the post-fix FM-7 rate at 0 / 209. Full breakdown in
 [`research/2026-04-21-tls-impersonation-spike.md`](research/2026-04-21-tls-impersonation-spike.md)
 and [`docs/ZERO-KEY.md`](docs/ZERO-KEY.md).
 
@@ -118,10 +132,11 @@ release-readiness ADR in
   configured). Every attempt returns the same shape.
 - **A narrow muscle in the brains-and-muscles pattern.** Your frontier
   model is the brain; `companyctx` is one of many CLIs it pipes through.
-- **A local-first memory layer — by design, landing later.** The SQLite
-  cache is scoped as Vertical Memory: a queryable local B2B dataset that
-  compounds as a byproduct of normal use. It is **not wired in v0.2** —
-  `--from-cache` / `--refresh` are deferred to #9.
+- **A local-first memory layer.** The SQLite cache is Vertical Memory: a
+  queryable local B2B dataset that compounds as a byproduct of normal
+  use. Wired via `--from-cache` / `--refresh` / `--no-cache` on `fetch`
+  and the `cache list` / `cache clear` subcommands. XDG paths via
+  `platformdirs`; schema-versioned migrations.
 
 ### ISN'T
 
@@ -218,11 +233,11 @@ context means.
 
 ## Install
 
-`v0.2.0` is the current release (schema-breaking envelope bump):
+`v0.4.0` is the current release:
 
 ```bash
 pipx install companyctx
-companyctx --version   # companyctx 0.2.0
+companyctx --version   # companyctx 0.4.0
 companyctx fetch acme-bakery.com --mock --json
 ```
 
@@ -243,18 +258,19 @@ companyctx --help
 - **Graceful-partial always.** Providers never raise uncaught. Every
   failure maps to `ProviderRunMetadata.status` per provider and the
   top-level `status` on the envelope.
-- **Vertical Memory (design invariant, not yet wired).** The SQLite cache
-  is designed to compound into a queryable local B2B dataset under
-  [XDG paths](https://specifications.freedesktop.org/basedir-spec/); the
-  schema-versioned migrations and `--refresh` / `--from-cache` flags are
-  reserved in the CLI surface but not implemented in v0.2 — they reject
-  with a tracking-issue pointer (#9).
+- **Vertical Memory.** The SQLite cache compounds into a queryable local
+  B2B dataset under
+  [XDG paths](https://specifications.freedesktop.org/basedir-spec/) via
+  the `--refresh` / `--from-cache` / `--no-cache` flags and the
+  `cache list` / `cache clear` subcommands. Schema-versioned migrations
+  make cache evolution explicit (see [`docs/SPEC.md`](docs/SPEC.md) §Cache).
 - **Provider pluggability.** Every deterministic call class is discovered
-  via Python entry points (`companyctx.providers`). v0.2 ships
+  via Python entry points (`companyctx.providers`). Today
   `site_text_trafilatura` (zero-key) and `smart_proxy_http` (user-keyed,
-  vendor-agnostic). Direct-API providers (Google Places, Yelp, YouTube,
-  Brave) and the `readability-lxml` bus-factor fallback are scaffolded for
-  later milestones. See [`docs/PROVIDERS.md`](docs/PROVIDERS.md).
+  vendor-agnostic) are registered. Direct-API providers (Google Places,
+  Yelp, YouTube, Brave) and the `readability-lxml` bus-factor fallback are
+  scaffolded for later milestones. See
+  [`docs/PROVIDERS.md`](docs/PROVIDERS.md).
 - **robots.txt respected by default.** `--ignore-robots` is an explicit
   CLI-only flag; never settable via TOML or env.
 - **Deterministic mocks.** `fixtures/<site>/` drives `--mock`; re-runs
@@ -262,7 +278,7 @@ companyctx --help
 
 ## Providers
 
-Shipped in v0.2 (run `companyctx providers list` to introspect):
+Registered today (run `companyctx providers list` to introspect):
 
 | Slug | Tier | Category | Key | Cost |
 |---|---|---|---|---|
@@ -304,7 +320,7 @@ companyctx/            # package
     smart_proxy_base.py         # shared helpers for smart-proxy providers
 SKILL.md               # ~150-token agent-discovery surface (not MCP)
 docs/
-  SPEC.md              # frozen spec snapshot (v0.2 envelope)
+  SPEC.md              # frozen spec snapshot (v0.4 envelope)
   SCHEMA.md            # Pydantic envelope in detail
   ARCHITECTURE.md      # brains-and-muscles + Deterministic Waterfall + Vertical Memory
   ZERO-KEY.md          # honest anti-bot coverage + graceful-partial contract

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,11 +35,11 @@ company so an agent can reason about it, rather than reading raw HTML.
 - The `data.site` field is the identifier; `data.pages` holds homepage-
   derived content (`homepage_text`, `about_text`, `services`, `tech_stack`).
 - `data.reviews` / `data.social` / `data.signals` / `data.mentions` are
-  reserved in the schema but stay `null` in v0.2 — the providers that
+  reserved in the schema but stay `null` today — the providers that
   fill them are deferred (see `docs/SPEC.md`). Schema-locked partials,
   not bugs.
 
-**Envelope shape (v0.2).**
+**Envelope shape.**
 
 ```json
 {

--- a/companyctx/__init__.py
+++ b/companyctx/__init__.py
@@ -21,7 +21,7 @@ from companyctx.schema import (
     SocialSignals,
 )
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "SCHEMA_VERSION",

--- a/companyctx/cli.py
+++ b/companyctx/cli.py
@@ -9,9 +9,9 @@ Exposes the public contract described in ``docs/SPEC.md``:
 - ``cache list`` / ``cache clear`` — Vertical Memory plumbing (COX-6 / #9).
 - ``batch <csv>`` — batch mode stub (still gated on the batch slice).
 
-Several flags and subcommands in v0.3 are still stubs. They fail loudly
-rather than silently accepting input and doing nothing — see issue #68 for
-the honesty pass.
+Several flags and subcommands are still stubs. They fail loudly rather
+than silently accepting input and doing nothing — see issue #68 for the
+honesty pass.
 """
 
 from __future__ import annotations
@@ -168,7 +168,7 @@ _FORMAT_OPT = typer.Option(
     "--json/--markdown",
     help=(
         "Output format. --json is the supported contract. "
-        "--markdown is experimental and not implemented in v0.2.0 — "
+        "--markdown is experimental and not implemented — "
         "runs fail fast (see issue #68)."
     ),
 )
@@ -185,7 +185,7 @@ _NO_CACHE_OPT = typer.Option(
 _CONFIG_OPT = typer.Option(
     None,
     "--config",
-    help="TOML config path. (Not implemented in v0.3 — see issue #9.)",
+    help="TOML config path. (Not implemented yet — see issue #9.)",
     callback=_reject_config_flag,
 )
 _MOCK_FETCH_OPT = typer.Option(

--- a/companyctx/cli.py
+++ b/companyctx/cli.py
@@ -78,7 +78,7 @@ def _reject_config_flag(value: Path | None) -> Path | None:
     """Reject ``--config <path>`` until the TOML loader lands."""
     if value is not None:
         raise typer.BadParameter(
-            "--config is not implemented in v0.3 — "
+            "--config is not implemented yet — "
             f"see https://github.com/dmthepm/companyctx/issues/{_CONFIG_ISSUE}"
         )
     return value
@@ -87,7 +87,7 @@ def _reject_config_flag(value: Path | None) -> Path | None:
 def _fail_stub(command: str, issue: int) -> None:
     """Print a loud stderr message and exit non-zero for a not-yet-wired command."""
     typer.secho(
-        f"{command} is not implemented in v0.3 — "
+        f"{command} is not implemented yet — "
         f"see https://github.com/dmthepm/companyctx/issues/{issue}",
         fg=typer.colors.RED,
         err=True,
@@ -255,7 +255,7 @@ def fetch(
     if not json_out:
         # Markdown output belongs in a downstream synthesis layer, not here.
         typer.secho(
-            "--markdown is not implemented in v0.3; rerun with --json.",
+            "--markdown is not implemented; rerun with --json.",
             fg=typer.colors.RED,
             err=True,
         )

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -12,7 +12,7 @@
 
 ---
 
-# companyctx — spec (v0.2)
+# companyctx — spec (v0.4)
 
 ## Purpose
 
@@ -28,7 +28,7 @@ layer that consumes the JSON. No people data in v0.1 (company side only).
 
 Built with Typer. Conforms to clig.dev.
 
-Shipped in v0.3:
+Shipped today:
 
 | Command | Behavior |
 |---|---|
@@ -39,7 +39,7 @@ Shipped in v0.3:
 | `companyctx cache list [--json]` | Latest cached envelope per host (one row per host). |
 | `companyctx cache clear --site X` / `--older-than 7d` | Prune cached rows; at least one filter is required. |
 
-Reserved in the CLI surface but **not wired** in v0.3 — invoking them
+Reserved in the CLI surface but **not wired** yet — invoking them
 prints a tracking-issue pointer to stderr and exits non-zero, so agents
 don't build on a contract we don't honour yet:
 
@@ -51,8 +51,8 @@ Flags on `fetch`:
 
 - `--out <path>` — write JSON to a file instead of stdout.
 - `--json` / `--markdown` — `--json` is the supported contract.
-  `--markdown` is **experimental and not implemented** in v0.2; the CLI
-  rejects it with an explicit message so downstream pipelines don't ship a
+  `--markdown` is **experimental and not implemented**; the CLI rejects
+  it with an explicit message so downstream pipelines don't ship a
   silent contract (#68).
 - `--mock` — load from `fixtures/<site>/` instead of the network. Paired
   with `--fixtures-dir` (default `./fixtures`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "companyctx"
-version = "0.3.0"
+version = "0.4.0"
 description = "Deterministic B2B company context router. Zero keys. Schema-locked JSON your agent pipelines can actually trust."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -75,7 +75,7 @@ def test_top_level_literal_aliases_expose_expected_members() -> None:
 
 def test_package_version_is_current() -> None:
     """Pinned to current release — bump in the version-bump PR."""
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.4.0"
 
 
 def test_py_typed_marker_ships_with_package() -> None:


### PR DESCRIPTION
## Summary

- Cuts the `v0.4.0` release. Package version bumps `0.3.0` → `0.4.0`; `CHANGELOG.md` `[Unreleased]` → `[0.4.0] — 2026-04-23`.
- Tier 1 docs-drift sweep: `README.md` Status / Install / Vertical-Memory / Providers / Layout blocks refreshed to v0.4 reality (SQLite cache shipped via #93, FM-7 floor raised to 1024 bytes, NXDOMAIN routed to `no_provider_succeeded`, `schema_version` Literal `"0.4.0"`). `docs/SPEC.md` title `(v0.2)` → `(v0.4)` and three version-agnostic rephrasings. `SKILL.md` drops `(v0.2)` labels.
- `companyctx/cli.py` — all six user-facing "in v0.X" error / help / docstring strings rewritten version-agnostic (`yet`, `<empty>`) so they stop churning every release.
- `examples/` prose drift (~25 lines of `v0.2` EXPECTED-OUTPUT labels) is explicitly **out of scope** — tracked as follow-up #106. NXDOMAIN `error.suggestion` DNS-specific text deviation is tracked as #105 and will be called out as Known Behavior in the v0.4.0 release notes.

## Commits

- `d428cfe` — docs(readme): refresh Status for v0.4 — cache shipped, FM-7 floor, schema 0.4.0
- `d542acd` — docs(spec): refresh title v0.2→v0.4; version-agnostic phrasing for deferred flags
- `88cbac1` — docs(skill): drop v0.2 label from envelope-shape section and null-slot bullet
- `49b3ca3` — fix(cli): version-agnostic error strings for unimplemented features
- `5252f3b` — chore(release): bump version to 0.4.0
- `e624cfb` — fix(cli): complete version-agnostic rewrite — --config help text (follow-up to 49b3ca3)

## Acceptance (from #104)

Step 1 — RC dogfood pass:

- [x] Install-path: all four commands exit 0.
- [x] Pre-bump envelope emits `schema_version: "0.4.0"` (Literal already bumped).
- [x] FM-7 trigger fires on a real brochure-thin site with `error.code: empty_response`.
- [x] Cache round-trip works: fetch → list → from-cache → clear → list.
- [x] NXDOMAIN routes to `no_provider_succeeded` (not `ssrf_rejected`) — DNS detail in `error.message`, suggestion text deferred to #105.
- [x] All three bad-input cases reject with clear messages.
- [x] Summary comment posted on this issue.

Step 2 — Docs drift sweep:

- [x] Drift grep commands all return clean (or fixes committed).
- [x] `docs/RISK-REGISTER.md` FM-7 entry already describes 1024-byte floor as current.
- [x] All 9 `EnvelopeErrorCode` Literal members documented in `docs/SPEC.md` + `docs/SCHEMA.md`.
- [x] No stale `"0.3.0"` strings in living docs (CHANGELOG historical exempt).
- [x] Drift fixes committed on this branch rather than a separate `docs:` PR, per runbook clarification.

Step 3 — Version bump:

- [x] `pyproject.toml` version `0.3.0` → `0.4.0`.
- [x] `companyctx/__init__.py` `__version__` → `0.4.0`.
- [x] `CHANGELOG.md` `[Unreleased]` → `[0.4.0] — 2026-04-23`.
- [x] `tests/test_public_api.py::test_package_version_is_current` asserts `"0.4.0"`.
- [x] Commit titled `chore(release): bump version to 0.4.0`; body lists bundled PRs + breaking changes.

Steps 4 (tag + PyPI publish) + 5 (post-release close + #103 hand-off) — blocked on this PR merging.

## Test plan

- [x] `ruff format --check .` — 48 files already formatted.
- [x] `ruff check .` — all checks passed.
- [x] `mypy companyctx tests` — no issues in 39 source files.
- [x] `pytest -q` — 394 passed in 4.90s (re-ran after `e624cfb`).
- [x] Live smokes executed against `--mock` acme-bakery (schema_version 0.4.0, cache round-trip byte-identical) and a real brochure-thin site from the partner dream100 (FM-7 fires: `status: degraded`, `error.code: empty_response`). Evidence in `.context/rc-dogfood-v0.4.0.md` (gitignored).

## Breaking changes

BREAKING CHANGE: `schema_version` Literal bumped `"0.3.0"` → `"0.4.0"`. Consumers that persist v0.3 envelopes must re-fetch.

BREAKING CHANGE: `EMPTY_RESPONSE_BYTES` raised 64 → 1024. HTTP 200 with 64–1023 bytes of extracted text now surfaces as `status: degraded + error.code: empty_response` (was silent-success `ok` in v0.3). This is the v0.3 Known Limitation being retired in behavior.

BREAKING CHANGE: NXDOMAIN / unresolvable hostnames now route to `error.code: no_provider_succeeded` instead of `ssrf_rejected`. Downstream code branching on `ssrf_rejected` for DNS failures must also handle `no_provider_succeeded`.

Closes #104