### PR TITLE
docs(research,decision): COX-64 reviews-provider survey + ADR (Slice A)

### DIFF
--- a/decisions/2026-04-23-reviews-provider-selection.md
+++ b/decisions/2026-04-23-reviews-provider-selection.md
@@ -49,7 +49,7 @@ candidates measured on the same corpus, decision cited back to the
 numbers. Issue [#116](https://github.com/dmthepm/companyctx/issues/116)
 retrofits that pattern.
 
-### Three facts that force the decision regardless of probe outcome
+### Four facts that force the decision regardless of probe outcome
 
 1. **Google Places Legacy is no longer enablable for new projects
    (since 2025-03-01).** Existing keys continue to work, but any new
@@ -65,6 +65,15 @@ retrofits that pattern.
    2026-05-19).** Any ADR naming SerpAPI as `accepted` during active
    litigation is a ship-and-regret risk. SerpAPI is dropped from the
    shortlist pre-probe.
+4. **The agentic alternative is on the table.** Devon's 2026-04-23
+   pressure test — *"is Claude somehow finding reviews and counts just
+   with web..."* — introduced a fifth candidate (WebSearch + LLM
+   parsing) that does not fit the "structured third-party provider"
+   frame. If this wins on the partner corpus, the outcome is the
+   removal of `reviews_google_places` from the waterfall entirely, not
+   the replacement of one provider with another. Outcome E below
+   carries that branch, and it is pre-registered as the first-matching
+   branch in the decision rule.
 
 ### Partner-shaped reality check
 
@@ -81,27 +90,39 @@ single-provider or user-pluggable.
 
 ### Finalist shortlist for the Slice B probe
 
-Three providers, measured head-to-head on the same 10-site corpus:
+Five candidates, measured head-to-head on the same 10-site corpus. Two
+slots were added after the initial three were finalized: **WebSearch +
+LLM parsing** (per Devon's 2026-04-23 scope-expansion comment on #116)
+and **DataForSEO Google Reviews API** (per the COX-63 cross-issue
+audit).
 
 1. **Google Places API (New) — Enterprise SKU.** First-party;
    `rating` + `userRatingCount` in the Enterprise tier; migration target
    for our Legacy-based current implementation.
-2. **Yelp Fusion Plus** ($9.99/1k; 500 calls/day cap; US-only). First-party;
-   free during 30-day trial at partner's volume.
-3. **Apify `compass/crawler-google-places`.** Represents the
-   scraper-actor category the issue specifically asked about; highest
-   usage in the Apify Google Maps namespace; nominal ~$2.10/1k.
-   Probe measures **effective cost including residential-proxy surcharge**
-   (post-Feb-2026 limited-view lockdown).
+2. **Apify `compass/crawler-google-places`.** Scraper-actor category;
+   highest usage in the Apify Google Maps namespace; nominal ~$2.10/1k.
+   Probe measures **effective cost including residential-proxy
+   surcharge** (post-Feb-2026 limited-view lockdown).
+3. **WebSearch + LLM parsing.** The agentic alternative. No dedicated
+   provider module; the partner's own agent pipeline does a single
+   WebSearch turn and parses the SERP card for rating + count.
+   Triggers Outcome E below if it wins.
+4. **DataForSEO Google Reviews API.** Aggregator-family; claim of
+   ~$0.00075/10 reviews pending 2026-pricing verification as the first
+   step of Slice B. ToS posture one layer removed from direct scraping
+   with no active-litigation signal on file.
+5. **Yelp Fusion Plus** ($9.99/1k; 500 calls/day cap; US-only).
+   First-party; free during 30-day trial at partner's volume. First-to-
+   drop if Slice B budget or wall-clock tightens.
 
 See `research/2026-04-23-reviews-extraction-method-survey.md` for the
 eliminations (Essentials/Pro, SerpAPI, Outscraper, BrightData, direct
 scraping) and their rationale.
 
-### Four-branch outcome structure
+### Five-branch outcome structure
 
 After Slice B measurement, this ADR's `Decision` section will be
-rewritten to one of **exactly these four outcomes** (the branch is
+rewritten to one of **exactly these five outcomes** (the branch is
 picked by the pre-registered decision rule in the research doc):
 
 #### Outcome A — Migrate-in-place to Google Places API (New) Enterprise
@@ -153,17 +174,66 @@ marks this as the feature release.
 #### Outcome D — Keep Legacy Google Places, reopen probe
 
 **Trigger:** Probe results inconclusive (coverage < 0.8 across all
-three finalists, or data consistency divergence > 0.3 stars making
+five finalists, or data consistency divergence > 0.3 stars making
 rankings unstable, or Apify effective-cost-including-proxy puts it at
 parity with Google New Enterprise), OR the probe runs up against
 key-provisioning or actor-breakage issues that invalidate the
 measurement.
 
 **Action:** No code change. Ticket re-opens with a wider or different
-shortlist. Accept that the v0.3 status quo was defensible and the
-cost-saving hypothesis did not survive contact with evidence. This
-outcome is listed explicitly to prevent a "we spent the budget, we
-must switch" motivated-reasoning error.
+shortlist (Foursquare, post-ruling SerpAPI, DataLabs). Accept that the
+v0.3 status quo was defensible and the cost-saving hypothesis did not
+survive contact with evidence. This outcome is listed explicitly to
+prevent a "we spent the budget, we must switch" motivated-reasoning
+error.
+
+#### Outcome E — Remove the reviews provider entirely
+
+**Trigger:** WebSearch + LLM parsing clears coverage ≥ 0.85 on the
+partner corpus AND effective cost (including Claude tokens + WebSearch
+tool cost) ≤ 1.5¢/site AND JSON-format compliance rate is 10/10 on the
+probe slugs AND data consistency vs. Google baseline is within ±0.3
+stars on co-present businesses.
+
+**Action:** The highest-leverage outcome available to this spike.
+
+1. Delete `companyctx/providers/reviews_google_places.py` and its
+   tests / fixtures / entry-point registration in `pyproject.toml:60`.
+2. Remove the `reviews` provider-category references from
+   `docs/PROVIDERS.md`; the category stays in the schema (for any
+   downstream who wires their own) but the default waterfall emits
+   `data.reviews: null` and documents **the agentic pattern** as the
+   recommended downstream integration:
+   > For reviews, do not wire a dedicated provider. Instead, at the
+   > synthesis layer of your agent pipeline, issue a `WebSearch("<name>
+   > <city> reviews")` turn and parse the SERP card. Example: see
+   > `examples/reviews_via_websearch.py`.
+3. Add `examples/reviews_via_websearch.py` showing the prompt template,
+   the JSON-return contract, and a validator that rejects hallucinated
+   numbers.
+4. Remove `GOOGLE_PLACES_API_KEY` from the setup documentation; it
+   remains honored for any user who has not yet migrated their pipeline
+   to the agentic pattern, but the zero-key path no longer gates on it.
+5. CHANGELOG v0.5 marks this as a **BREAKING CHANGE** with a
+   migration note: users whose pipelines explicitly consume
+   `data.reviews` must either (a) add the WebSearch+parse step upstream
+   of the companyctx call, or (b) wire their own reviews provider via
+   entry point before the v0.5 upgrade. Migration path is documented
+   with both options so the partner — and any downstream user — can
+   pick.
+6. Update the zero-key README hero to reflect that reviews are
+   **outside** the companyctx schema-locked output in v0.5 and that
+   this is an intentional narrowing based on measurement.
+
+This outcome is listed first in the decision rule not because it is
+most likely but because it is most **consequential** — collapsing a
+whole provider surface into an agent-tool pattern is the largest
+scope-narrowing move the spike can produce, and narrowing scope to the
+deterministic-CLI wedge is the repo's stated preference when evidence
+supports it. See ADR
+`decisions/2026-04-20-zero-key-stealth-strategy.md` for the "every
+attempt maps to the same envelope shape; providers are replaceable; the
+envelope is not" posture that Outcome E operationalizes.
 
 ### Explicitly rejected outcomes
 
@@ -191,14 +261,21 @@ must switch" motivated-reasoning error.
    maps probe numbers to outcome branches before we see the numbers.
    If Google New Enterprise wins on the rule, we keep it even if the
    partner mood on the day of the probe is "we want to switch."
-3. **Honoring the partner's own fallback posture as the probable
-   outcome shape.** Outcome C (composite) is the one that best matches
-   `new-signal-studio`'s observed behavior of running Yelp / Angi / BBB
-   / Trustindex when Google returns nothing. Outcome A (stay, just
-   migrate) is defensible if coverage is high. Outcomes B and D are
-   listed because they are real branches the probe could land on, not
-   because we expect them.
-4. **Single-provider > pluggable.** `companyctx`'s adoption wedge is "one
+3. **Honoring the partner's own fallback posture as a probable
+   outcome shape.** Outcome C (composite) matches `new-signal-studio`'s
+   observed behavior of running Yelp / Angi / BBB / Trustindex when
+   Google returns nothing. Outcome A (stay, just migrate) is defensible
+   if coverage is high. Outcomes B and D are listed because they are
+   real branches the probe could land on, not because we expect them.
+4. **Outcome E (remove the provider) is the highest-leverage
+   branch.** If WebSearch + LLM parsing clears the decision rule's
+   thresholds, the right move is not to replace one provider with a
+   cheaper one but to collapse the provider surface to zero and
+   document the agentic pattern. Narrowing scope to the deterministic-
+   CLI wedge is the repo's stated preference when evidence supports
+   it; removing a paid-API dependency from the default path is a
+   clean realization of that preference.
+5. **Single-provider > pluggable.** `companyctx`'s adoption wedge is "one
    command, deterministic output, no config knobs." A pluggable
    `COMPANYCTX_REVIEWS_PROVIDER=...` toggle contradicts that wedge.
 
@@ -209,7 +286,8 @@ must switch" motivated-reasoning error.
 | "Stick with Legacy Google Places indefinitely" | Legacy is non-enablable for new GCP projects since 2025-03-01. Even if the probe favors Google, migration to New Enterprise is required on time-horizon grounds. |
 | "Ship pluggable provider config" | Contradicts the deterministic-CLI wedge; adds maintenance across N providers that we don't have evidence we need. Rejected per Rationale #4. |
 | "Just switch to Apify, cheaper and done" | Pre-probe evidence says "cheaper" is partial — residential-proxy cost after Feb-2026 lockdown is the open question the probe answers. Motivated-reasoning-avoidance: let the numbers pick. |
-| "Broader shortlist — include SerpAPI / DataForSEO / Outscraper" | SerpAPI eliminated on litigation. Outscraper eliminated as it wraps the same scraped Google data as Apify with zero ToS improvement. DataForSEO evaluated but pricing transparency is insufficient for a same-day 10-site probe inside $15 budget; reopen if outcomes A-D all fail. |
+| "Broader shortlist — include SerpAPI / Outscraper" | SerpAPI eliminated on litigation. Outscraper eliminated as it wraps the same scraped Google data as Apify with zero ToS improvement. **DataForSEO was added to the shortlist** after initial publication, per the COX-63 cross-issue audit note. |
+| "Skip WebSearch + LLM parsing — it's not a third-party API" | The question framing itself was skeptical ("is Claude somehow finding reviews just with web"). Excluding it because it doesn't fit the "structured third-party provider" mental model would reproduce the v0.3 error of shipping a provider without measuring the alternatives. Outcome E is the branch that takes the agentic answer seriously. |
 | "Expand probe to 100 sites for statistical significance" | The measurement question at stake is cost-and-coverage-fit at partner-scale, not 3-decimal-place statistics. n=10 is enough to separate providers that differ by >20%; if the numbers come in tighter than that, the ADR branches to Outcome D (reopen) rather than picking between near-ties. |
 
 ## Risks

--- a/decisions/2026-04-23-reviews-provider-selection.md
+++ b/decisions/2026-04-23-reviews-provider-selection.md
@@ -21,11 +21,13 @@ linked_issues:
 
 **Proposed 2026-04-23. Pending spike.**
 
-Per the repo rule in `CLAUDE.md` ("Never name a vendor in public docs
-before measurement"), this ADR is not `accepted` and does not commit
-`companyctx` to a chosen provider. The desktop survey in
+Following the precedent set by
+`decisions/2026-04-20-zero-key-stealth-strategy.md` — proposed first,
+accepted only after a same-corpus measurement spike landed the numbers
+— this ADR does not name a chosen vendor in its `accepted` state until
+the Slice B live probe runs. The desktop survey in
 `research/2026-04-23-reviews-extraction-method-survey.md` produced a
-shortlist of three finalists; the live 10-site probe (Slice B of issue
+shortlist of five finalists; the 10-site probe (Slice B of issue
 [#116](https://github.com/dmthepm/companyctx/issues/116)) is what flips
 this ADR to `accepted` and names a specific provider or composition.
 
@@ -38,15 +40,14 @@ v0.3/v0.4. **This ADR does not authorize any code change.**
 ### The process gap this closes
 
 `v0.3` shipped `reviews_google_places` (Legacy Google Places) as the
-sole reviews provider at ~5.4¢/call. That choice was informed by a v0.1
-desktop survey
-(`noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md`)
-but was **not backed by a same-corpus head-to-head measurement against
-alternatives.** The TLS-impersonation library spike (#21 /
-`decisions/2026-04-20-zero-key-stealth-strategy.md`) is the pattern the
-reviews slot should have followed from the start: candidates enumerated,
-candidates measured on the same corpus, decision cited back to the
-numbers. Issue [#116](https://github.com/dmthepm/companyctx/issues/116)
+sole reviews provider at ~5.4¢/call. That choice was informed by an
+earlier informal desktop landscape review but was **not backed by a
+same-corpus head-to-head measurement against alternatives.** The
+TLS-impersonation library spike (#21 /
+`decisions/2026-04-20-zero-key-stealth-strategy.md`) is the pattern
+the reviews slot should have followed from the start: candidates
+enumerated, candidates measured on the same corpus, decision cited
+back to the numbers. Issue [#116](https://github.com/dmthepm/companyctx/issues/116)
 retrofits that pattern.
 
 ### Four facts that force the decision regardless of probe outcome
@@ -60,31 +61,25 @@ retrofits that pattern.
 2. **The fields we need (`rating`, `userRatingCount`) are in the
    Enterprise SKU of the New API.** Essentials and Pro tiers do not
    return them. The "downgrade to Essentials" outcome listed in the
-   issue is architecturally impossible.
+   issue is architecturally impossible. A further refinement: `rating`
+   + `userRatingCount` + `websiteUri` are in the **Enterprise** tier,
+   whereas full `reviews` text and `reviewSummary` fields trigger the
+   pricier **Enterprise + Atmosphere** tier. Our downstream consumers
+   use rating + count only, so the correct field mask stays on
+   Enterprise and avoids Atmosphere — a concrete ~$5 / 1000 request
+   saving we should lock into the implementation.
 3. **SerpAPI is in active Google DMCA litigation (Dec-2025; hearing
    2026-05-19).** Any ADR naming SerpAPI as `accepted` during active
    litigation is a ship-and-regret risk. SerpAPI is dropped from the
    shortlist pre-probe.
-4. **The agentic alternative is on the table.** Devon's 2026-04-23
-   pressure test — *"is Claude somehow finding reviews and counts just
-   with web..."* — introduced a fifth candidate (WebSearch + LLM
-   parsing) that does not fit the "structured third-party provider"
-   frame. If this wins on the partner corpus, the outcome is the
+4. **The agentic alternative is on the table.** A scope-expansion
+   comment on the issue thread introduced a fifth candidate (WebSearch
+   + LLM parsing) that does not fit the "structured third-party
+   provider" frame. If this wins on the probe, the outcome is the
    removal of `reviews_google_places` from the waterfall entirely, not
    the replacement of one provider with another. Outcome E below
    carries that branch, and it is pre-registered as the first-matching
    branch in the decision rule.
-
-### Partner-shaped reality check
-
-The partner's `new-signal-studio` pipeline already runs a
-**multi-source fallback** (Google → Yelp → HomeAdvisor → Angi → BBB →
-Trustindex), treating any "INSUFFICIENT DATA" event as a
-pipeline-continues-with-missing-field rather than a stall. The partner
-does not need the "one true review provider"; the partner needs
-"rating + count shows up from somewhere reliable." That shape
-pushes the ADR toward **composite fallback** over either
-single-provider or user-pluggable.
 
 ## Decision (proposed)
 
@@ -92,28 +87,29 @@ single-provider or user-pluggable.
 
 Five candidates, measured head-to-head on the same 10-site corpus. Two
 slots were added after the initial three were finalized: **WebSearch +
-LLM parsing** (per Devon's 2026-04-23 scope-expansion comment on #116)
-and **DataForSEO Google Reviews API** (per the COX-63 cross-issue
-audit).
+LLM parsing** (the agentic alternative) and **DataForSEO Google
+Reviews API** (aggregator-family, cross-issue candidate from the
+COX-63 parallel audit).
 
-1. **Google Places API (New) — Enterprise SKU.** First-party;
-   `rating` + `userRatingCount` in the Enterprise tier; migration target
-   for our Legacy-based current implementation.
+1. **Google Places API (New) — Enterprise SKU** (strict field mask
+   excluding Atmosphere). First-party; `rating` + `userRatingCount` +
+   `websiteUri` in the Enterprise tier; migration target for the
+   Legacy-based current implementation.
 2. **Apify `compass/crawler-google-places`.** Scraper-actor category;
    highest usage in the Apify Google Maps namespace; nominal ~$2.10/1k.
    Probe measures **effective cost including residential-proxy
    surcharge** (post-Feb-2026 limited-view lockdown).
 3. **WebSearch + LLM parsing.** The agentic alternative. No dedicated
-   provider module; the partner's own agent pipeline does a single
-   WebSearch turn and parses the SERP card for rating + count.
-   Triggers Outcome E below if it wins.
+   provider module; an agent does a single WebSearch turn and parses
+   the SERP card for rating + count. Triggers Outcome E below if it
+   wins.
 4. **DataForSEO Google Reviews API.** Aggregator-family; claim of
-   ~$0.00075/10 reviews pending 2026-pricing verification as the first
-   step of Slice B. ToS posture one layer removed from direct scraping
-   with no active-litigation signal on file.
+   ~$0.00075/10 reviews pending 2026-pricing verification as the
+   first step of Slice B. ToS posture one layer removed from direct
+   scraping with no active-litigation signal on file.
 5. **Yelp Fusion Plus** ($9.99/1k; 500 calls/day cap; US-only).
-   First-party; free during 30-day trial at partner's volume. First-to-
-   drop if Slice B budget or wall-clock tightens.
+   First-party; free during 30-day trial at the probe's volume.
+   First-to-drop if Slice B budget or wall-clock tightens.
 
 See `research/2026-04-23-reviews-extraction-method-survey.md` for the
 eliminations (Essentials/Pro, SerpAPI, Outscraper, BrightData, direct
@@ -132,28 +128,23 @@ effective-cost(Google New Enterprise) ≤ 1.5 × effective-cost(cheapest
 alternative).
 
 **Action:** Replace `companyctx/providers/reviews_google_places.py`
-with a New-API implementation using **Text Search (New) + Place Details
-(New) with an explicit Enterprise-tier field mask that deliberately
-excludes Atmosphere-tier fields**. The exact field mask is
-`id,displayName,rating,userRatingCount,websiteUri` — nothing else. The
-partner's downstream pipeline consumes rating + count only; requesting
-full `reviews` or `reviewSummary` would trigger the Atmosphere SKU at
-$25/1k instead of $20/1k Enterprise and produce data we do not use. The
-GPT deep-research pass (cross-reference in the research doc) explicitly
-documents this SKU split; Outcome A's action list encodes it as a hard
-constraint, not a nice-to-have:
+with a New-API implementation using **Text Search (New) + Place
+Details (New) with an explicit Enterprise-tier field mask that
+deliberately excludes Atmosphere-tier fields**. The exact field mask
+is `id,displayName,rating,userRatingCount,websiteUri` — nothing else.
+Default downstream consumers use rating + count only; requesting full
+`reviews` or `reviewSummary` would trigger the Atmosphere SKU at
+$25/1k instead of $20/1k Enterprise and produce data we do not use.
 
-- Text Search (New) Enterprise: $35/1k, 1k/mo free. At partner
-  3k/mo volume after free cap: $70/mo.
-- Place Details (New) Enterprise: $20/1k, 1k/mo free. At partner
-  3k/mo after free cap: $40/mo.
-- **Combined post-free Google bill at 3k/mo: ~$110/mo**, vs. the
-  $175/mo the issue body estimates for Legacy Pro. Outcome A is the
-  migration path AND a ~37% cost reduction on the Google leg alone,
-  independent of any switch to a different provider.
+- Text Search (New) Enterprise: $35/1k, 1k/mo free.
+- Place Details (New) Enterprise: $20/1k, 1k/mo free.
+- **Combined post-free Google bill at 3k/mo volume: ~$110/mo**, vs.
+  the ~$175/mo Legacy Pro figure implied by the v0.3 cost model.
+  Outcome A is the migration path AND a ~37% cost reduction on the
+  Google leg, independent of any switch to a different provider.
 
 Same provider slug, same envelope shape, updated cost constants.
-Breaking change is internal only — no partner-facing env-var rename;
+Breaking change is internal only — no operator-facing env-var rename;
 the new provider reads the same `GOOGLE_PLACES_API_KEY` env var. A
 test must lock the field mask against regression — if a future edit
 widens it into the Atmosphere tier, pytest should fail. CHANGELOG
@@ -162,13 +153,13 @@ cost reduction, and the unchanged envelope shape.
 
 #### Outcome B — Switch default to Yelp Fusion Plus
 
-**Trigger:** Yelp coverage ≥ 0.9 on the US-heavy partner corpus AND
-effective-cost(Yelp) < 0.5 × effective-cost(Google New Enterprise) AND
-data consistency vs. Google baseline within ±0.3 stars on co-present
-businesses.
+**Trigger:** Yelp coverage ≥ 0.9 on a US-heavy test corpus AND
+effective-cost(Yelp) < 0.5 × effective-cost(Google New Enterprise)
+AND data consistency vs. Google baseline within ±0.3 stars on
+co-present businesses.
 
-**Action:** Introduce `companyctx/providers/reviews_yelp_fusion.py` as
-the new default. The commented-out stub entry point at
+**Action:** Introduce `companyctx/providers/reviews_yelp_fusion.py`
+as the new default. The commented-out stub entry point at
 `pyproject.toml:61` becomes live. Google New Enterprise becomes the
 **Attempt-3-escape** for Yelp's US-only gap. New env var
 `YELP_FUSION_API_KEY`; CHANGELOG marks as **breaking** (v0.5 minor
@@ -178,18 +169,18 @@ bump with a migration note in the release notes, since the old
 #### Outcome C — Composite (Google New Enterprise → Yelp Fusion fallback)
 
 **Trigger:** Neither provider clears coverage ≥ 0.9 alone, but the
-**union** clears ≥ 0.95 AND the partner's session logs already show the
-composite shape is the operational posture.
+**union** clears ≥ 0.95 AND a fallback shape is warranted by the
+coverage gaps surfaced in the probe.
 
-**Action:** A new `reviews_composite.py` provider class that implements
-the composite attempt order internally, emits a **single** cost-cents
-number (actual billed, summing partial-attempt costs), and populates
-`ReviewsSignals` with a `source` field reflecting which provider
-actually produced the data. Partner must provision both
-`GOOGLE_PLACES_API_KEY` and `YELP_FUSION_API_KEY`; ADR documents
-that both are required under this outcome, which is a setup-friction
-tradeoff accepted in exchange for the coverage gain. CHANGELOG v0.5
-marks this as the feature release.
+**Action:** A new `reviews_composite.py` provider class that
+implements the composite attempt order internally, emits a **single**
+cost-cents number (actual billed, summing partial-attempt costs), and
+populates `ReviewsSignals` with a `source` field reflecting which
+provider actually produced the data. Operator must provision both
+`GOOGLE_PLACES_API_KEY` and `YELP_FUSION_API_KEY`; ADR documents that
+both are required under this outcome, a setup-friction tradeoff
+accepted in exchange for the coverage gain. CHANGELOG v0.5 marks
+this as the feature release.
 
 #### Outcome D — Keep Legacy Google Places, reopen probe
 
@@ -201,8 +192,8 @@ key-provisioning or actor-breakage issues that invalidate the
 measurement.
 
 **Action:** No code change. Ticket re-opens with a wider or different
-shortlist (Foursquare, post-ruling SerpAPI, DataLabs). Accept that the
-v0.3 status quo was defensible and the cost-saving hypothesis did not
+shortlist (Foursquare, post-ruling SerpAPI). Accept that the v0.3
+status quo was defensible and the cost-saving hypothesis did not
 survive contact with evidence. This outcome is listed explicitly to
 prevent a "we spent the budget, we must switch" motivated-reasoning
 error.
@@ -210,10 +201,10 @@ error.
 #### Outcome E — Remove the reviews provider entirely
 
 **Trigger:** WebSearch + LLM parsing clears coverage ≥ 0.85 on the
-partner corpus AND effective cost (including Claude tokens + WebSearch
-tool cost) ≤ 1.5¢/site AND JSON-format compliance rate is 10/10 on the
-probe slugs AND data consistency vs. Google baseline is within ±0.3
-stars on co-present businesses.
+test corpus AND effective cost (including agent tokens + WebSearch
+tool cost) ≤ 1.5¢/site AND JSON-format compliance rate is 10/10 on
+the probe slugs AND data consistency vs. Google baseline is within
+±0.3 stars on co-present businesses.
 
 **Action:** The highest-leverage outcome available to this spike.
 
@@ -224,23 +215,25 @@ stars on co-present businesses.
    downstream who wires their own) but the default waterfall emits
    `data.reviews: null` and documents **the agentic pattern** as the
    recommended downstream integration:
+
    > For reviews, do not wire a dedicated provider. Instead, at the
-   > synthesis layer of your agent pipeline, issue a `WebSearch("<name>
-   > <city> reviews")` turn and parse the SERP card. Example: see
-   > `examples/reviews_via_websearch.py`.
-3. Add `examples/reviews_via_websearch.py` showing the prompt template,
-   the JSON-return contract, and a validator that rejects hallucinated
-   numbers.
+   > synthesis layer of your agent pipeline, issue a
+   > `WebSearch("<name> <city> reviews")` turn and parse the SERP
+   > card. Example: see `examples/reviews_via_websearch.py`.
+
+3. Add `examples/reviews_via_websearch.py` showing the prompt
+   template, the JSON-return contract, and a validator that rejects
+   hallucinated numbers.
 4. Remove `GOOGLE_PLACES_API_KEY` from the setup documentation; it
-   remains honored for any user who has not yet migrated their pipeline
-   to the agentic pattern, but the zero-key path no longer gates on it.
+   remains honored for any user who has not yet migrated their
+   pipeline to the agentic pattern, but the zero-key path no longer
+   gates on it.
 5. CHANGELOG v0.5 marks this as a **BREAKING CHANGE** with a
    migration note: users whose pipelines explicitly consume
-   `data.reviews` must either (a) add the WebSearch+parse step upstream
-   of the companyctx call, or (b) wire their own reviews provider via
-   entry point before the v0.5 upgrade. Migration path is documented
-   with both options so the partner — and any downstream user — can
-   pick.
+   `data.reviews` must either (a) add the WebSearch+parse step
+   upstream of the companyctx call, or (b) wire their own reviews
+   provider via entry point before the v0.5 upgrade. Migration path
+   is documented with both options so downstream users can pick.
 6. Update the zero-key README hero to reflect that reviews are
    **outside** the companyctx schema-locked output in v0.5 and that
    this is an intentional narrowing based on measurement.
@@ -248,55 +241,48 @@ stars on co-present businesses.
 This outcome is listed first in the decision rule not because it is
 most likely but because it is most **consequential** — collapsing a
 whole provider surface into an agent-tool pattern is the largest
-scope-narrowing move the spike can produce, and narrowing scope to the
-deterministic-CLI wedge is the repo's stated preference when evidence
-supports it. See ADR
+scope-narrowing move the spike can produce, and narrowing scope to
+the deterministic-CLI wedge is the repo's stated preference when
+evidence supports it. See ADR
 `decisions/2026-04-20-zero-key-stealth-strategy.md` for the "every
-attempt maps to the same envelope shape; providers are replaceable; the
-envelope is not" posture that Outcome E operationalizes.
+attempt maps to the same envelope shape; providers are replaceable;
+the envelope is not" posture that Outcome E operationalizes.
 
 ### Explicitly rejected outcomes
 
 - **Pluggable reviews provider** (the issue's outcome #4). Ship one
   default that works; don't make the user pick. Pluggability for its
-  own sake is partner-facing choice overload and internal-facing
+  own sake is user-facing choice overload and internal-facing
   multi-fixture / multi-CI-cell maintenance debt. The `ProviderBase`
   abstraction already lets a user **replace** the default via entry
   point; no TOML/env toggle needed. If the probe surfaces a segment
-  (e.g., non-US partners) that needs a different provider, the fix is
-  a **segment-specific default** documented in a follow-up ADR, not a
-  generic pluggable-config surface.
+  that needs a different provider, the fix is a **segment-specific
+  default** documented in a follow-up ADR, not a generic
+  pluggable-config surface.
 - **Google Places Essentials downgrade.** Impossible — the required
   fields are not in that SKU (see Context #2).
 - **SerpAPI.** Eliminated on active litigation (see Context #3).
 
 ## Rationale
 
-1. **Measurement-before-naming is the repo rule.** The TLS spike
-   precedent (ADR accepted after `research/2026-04-21-...-spike.md`
-   landed the numbers) is the one this ADR follows. Proposed today,
-   accepted after Slice B.
+1. **Measurement-before-naming is the established pattern.** The TLS
+   spike precedent (ADR accepted after
+   `research/2026-04-21-tls-impersonation-spike.md` landed the
+   numbers) is the one this ADR follows. Proposed today, accepted
+   after Slice B.
 2. **Pre-registering the decision rule removes motivated-reasoning
    risk.** The research doc's `Decision rule (pre-committed)` section
    maps probe numbers to outcome branches before we see the numbers.
    If Google New Enterprise wins on the rule, we keep it even if the
-   partner mood on the day of the probe is "we want to switch."
-3. **Honoring the partner's own fallback posture as a probable
-   outcome shape.** Outcome C (composite) matches `new-signal-studio`'s
-   observed behavior of running Yelp / Angi / BBB / Trustindex when
-   Google returns nothing. Outcome A (stay, just migrate) is defensible
-   if coverage is high. Outcomes B and D are listed because they are
-   real branches the probe could land on, not because we expect them.
-4. **Outcome E (remove the provider) is the highest-leverage
-   branch.** If WebSearch + LLM parsing clears the decision rule's
-   thresholds, the right move is not to replace one provider with a
-   cheaper one but to collapse the provider surface to zero and
-   document the agentic pattern. Narrowing scope to the deterministic-
-   CLI wedge is the repo's stated preference when evidence supports
-   it; removing a paid-API dependency from the default path is a
-   clean realization of that preference.
-5. **Single-provider > pluggable.** `companyctx`'s adoption wedge is "one
-   command, deterministic output, no config knobs." A pluggable
+   mood on the day of the probe is "we want to switch."
+3. **Outcome E is the highest-leverage branch.** If WebSearch + LLM
+   parsing clears the decision rule's thresholds, the right move is
+   not to replace one provider with a cheaper one but to collapse the
+   provider surface to zero and document the agentic pattern.
+   Narrowing scope to the deterministic-CLI wedge is the repo's
+   stated preference when evidence supports it.
+4. **Single-provider > pluggable.** `companyctx`'s adoption wedge is
+   "one command, deterministic output, no config knobs." A pluggable
    `COMPANYCTX_REVIEWS_PROVIDER=...` toggle contradicts that wedge.
 
 ## Alternatives considered (at the ADR layer)
@@ -306,47 +292,44 @@ envelope is not" posture that Outcome E operationalizes.
 | "Stick with Legacy Google Places indefinitely" | Legacy is non-enablable for new GCP projects since 2025-03-01. Even if the probe favors Google, migration to New Enterprise is required on time-horizon grounds. |
 | "Ship pluggable provider config" | Contradicts the deterministic-CLI wedge; adds maintenance across N providers that we don't have evidence we need. Rejected per Rationale #4. |
 | "Just switch to Apify, cheaper and done" | Pre-probe evidence says "cheaper" is partial — residential-proxy cost after Feb-2026 lockdown is the open question the probe answers. Motivated-reasoning-avoidance: let the numbers pick. |
-| "Broader shortlist — include SerpAPI / Outscraper" | SerpAPI eliminated on litigation. Outscraper eliminated as it wraps the same scraped Google data as Apify with zero ToS improvement. **DataForSEO was added to the shortlist** after initial publication, per the COX-63 cross-issue audit note. |
+| "Broader shortlist — include SerpAPI / Outscraper" | SerpAPI eliminated on litigation. Outscraper eliminated as it wraps the same scraped Google data as Apify with zero ToS improvement. **DataForSEO is in the shortlist.** |
 | "Skip WebSearch + LLM parsing — it's not a third-party API" | The question framing itself was skeptical ("is Claude somehow finding reviews just with web"). Excluding it because it doesn't fit the "structured third-party provider" mental model would reproduce the v0.3 error of shipping a provider without measuring the alternatives. Outcome E is the branch that takes the agentic answer seriously. |
-| "Expand probe to 100 sites for statistical significance" | The measurement question at stake is cost-and-coverage-fit at partner-scale, not 3-decimal-place statistics. n=10 is enough to separate providers that differ by >20%; if the numbers come in tighter than that, the ADR branches to Outcome D (reopen) rather than picking between near-ties. |
+| "Expand probe to 100 sites for statistical significance" | The measurement question at stake is cost-and-coverage-fit at expected volume, not 3-decimal-place statistics. n=10 is enough to separate providers that differ by >20%; if the numbers come in tighter than that, the ADR branches to Outcome D (reopen) rather than picking between near-ties. |
 
 ## Risks
 
 - **Probe runs land in Outcome D (inconclusive).** Mitigation: the
   decision rule names this outcome explicitly so we don't force a
   switch under ambiguous numbers. Reopen with a different shortlist
-  (DataForSEO comes in from the bench; post-ruling SerpAPI if the
+  (Foursquare comes in from the bench; post-ruling SerpAPI if the
   case resolves favorably).
 - **Apify `compass/crawler-google-places` is broken on probe day.**
   Possible — the Feb-2026 limited-view event broke several scrapers.
   Mitigation: that *is* the measurement. If the actor returns zero on
-  our probe set at any proxy configuration, that's dispositive against
-  the scraper-actor category in general, and Outcome A/B/C take it.
+  the probe set at any proxy configuration, that's dispositive
+  against the scraper-actor category in general, and Outcome A/B/C
+  take it.
 - **Yelp Fusion free-trial misattribution.** A 30-day trial at
   500 calls/day could mask the $9.99/1k reality. Mitigation: probe
-  records **billed cost at post-trial rates** in the cost_incurred_cents
-  field (even if the actual invoice is $0 during the trial), making the
-  numbers comparable to Google's billed-from-day-one pricing.
-- **v0.5 breaking-change release notes are harsher than partner
-  tolerates.** Mitigation: Outcome A (migrate-in-place) is specifically
-  structured to be *non-breaking* (same env var, same envelope shape,
-  cost constants change under the hood). Outcomes B/C require an
-  env-var or setup change and get a `BREAKING CHANGE:` footer honestly.
-- **The partner cares less about this than the issue author does.**
-  Real possibility per the partner-shaped reality check above. Mitigation:
-  if the probe lands on Outcome A (migrate-in-place, near-invisible
-  change), ship it and move on. Don't force a multi-provider refactor
-  for a cost delta the downstream consumer isn't asking for.
+  records **billed cost at post-trial rates** in the
+  `cost_incurred_cents` field (even if the actual invoice is $0
+  during the trial), making the numbers comparable to Google's
+  billed-from-day-one pricing.
+- **v0.5 breaking-change release notes are harsher than downstream
+  users tolerate.** Mitigation: Outcome A (migrate-in-place) is
+  specifically structured to be *non-breaking* (same env var, same
+  envelope shape, cost constants change under the hood). Outcomes
+  B/C/E require an env-var or setup change and get a `BREAKING
+  CHANGE:` footer honestly.
 
 ## Open questions (resolved in Slice B)
 
-1. What is the **effective** cost per successful call for each finalist,
-   including proxy and actor-start overheads?
-2. What is the coverage rate on the 2 no-website-just-Facebook slugs,
-   where Google Places has historically returned INSUFFICIENT DATA per
-   the partner's session logs?
-3. Do ratings agree within ±0.3 stars across providers for the 4
-   medical/aesthetic slugs (high-overlap businesses)?
+1. What is the **effective** cost per successful call for each
+   finalist, including proxy and actor-start overheads?
+2. What is the coverage rate on the social-only edge-case slugs,
+   where Google Places has historically returned ZERO_RESULTS?
+3. Do ratings agree within ±0.3 stars across providers for the
+   same-address small-business slugs (high-overlap businesses)?
 4. Does the Apify actor's success rate survive a same-day re-run 2
    hours later? (Flakiness heuristic — if not, Outcome A/B is
    strengthened vs. Outcome C that relies on fallback working.)
@@ -358,14 +341,15 @@ When this ADR flips to `accepted`:
 1. Status frontmatter: `proposed` → `accepted`, add `accepted_on`.
 2. `docs/PROVIDERS.md` reviews section updated to name the chosen
    provider and link this ADR.
-3. One of Outcomes A / B / C implemented in a follow-up PR against the
-   implementation issue.
-4. `CHANGELOG.md` v0.5-unreleased entry under `### Changed` (Outcome A)
-   or `### BREAKING` (Outcomes B/C).
-5. Fixtures updated for the new provider (new response-shape JSON under
-   `fixtures/<slug>/`).
-6. Pre-push gates (`ruff`, `mypy`, `pytest --cov-fail-under=70`) remain
-   green. Provider tests mirror the structure of
+3. One of Outcomes A / B / C / E implemented in a follow-up PR
+   against the implementation issue.
+4. `CHANGELOG.md` v0.5-unreleased entry under `### Changed`
+   (Outcome A) or `### BREAKING` (Outcomes B/C/E).
+5. Fixtures updated for the new provider (new response-shape JSON
+   under `fixtures/<slug>/`).
+6. Pre-push gates (`ruff`, `mypy`, `pytest --cov-fail-under=70`)
+   remain green. Provider tests mirror the structure of
    `tests/test_reviews_google_places.py`.
 
-Nothing above ships in the same PR as this ADR. This PR is research + ADR only.
+Nothing above ships in the same PR as this ADR. This PR is research
++ ADR only.

--- a/decisions/2026-04-23-reviews-provider-selection.md
+++ b/decisions/2026-04-23-reviews-provider-selection.md
@@ -1,0 +1,273 @@
+---
+type: decision
+date: 2026-04-23
+topic: reviews-provider selection — measurement-driven successor to v0.3's Google Places Legacy choice
+status: proposed
+accepted_on: null
+linked_decisions:
+  - decisions/2026-04-20-zero-key-stealth-strategy.md
+linked_docs:
+  - docs/PROVIDERS.md
+  - docs/ARCHITECTURE.md
+linked_research:
+  - research/2026-04-23-reviews-extraction-method-survey.md
+linked_issues:
+  - https://github.com/dmthepm/companyctx/issues/116
+---
+
+# Reviews-provider selection
+
+## Status
+
+**Proposed 2026-04-23. Pending spike.**
+
+Per the repo rule in `CLAUDE.md` ("Never name a vendor in public docs
+before measurement"), this ADR is not `accepted` and does not commit
+`companyctx` to a chosen provider. The desktop survey in
+`research/2026-04-23-reviews-extraction-method-survey.md` produced a
+shortlist of three finalists; the live 10-site probe (Slice B of issue
+[#116](https://github.com/dmthepm/companyctx/issues/116)) is what flips
+this ADR to `accepted` and names a specific provider or composition.
+
+Until the probe runs, the default in `companyctx` remains
+`reviews_google_places` (Legacy Place Details), exactly as shipped in
+v0.3/v0.4. **This ADR does not authorize any code change.**
+
+## Context
+
+### The process gap this closes
+
+`v0.3` shipped `reviews_google_places` (Legacy Google Places) as the
+sole reviews provider at ~5.4¢/call. That choice was informed by a v0.1
+desktop survey
+(`noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md`)
+but was **not backed by a same-corpus head-to-head measurement against
+alternatives.** The TLS-impersonation library spike (#21 /
+`decisions/2026-04-20-zero-key-stealth-strategy.md`) is the pattern the
+reviews slot should have followed from the start: candidates enumerated,
+candidates measured on the same corpus, decision cited back to the
+numbers. Issue [#116](https://github.com/dmthepm/companyctx/issues/116)
+retrofits that pattern.
+
+### Three facts that force the decision regardless of probe outcome
+
+1. **Google Places Legacy is no longer enablable for new projects
+   (since 2025-03-01).** Existing keys continue to work, but any new
+   `companyctx` user trying to follow the Quickstart with a fresh GCP
+   project gets stuck at "cannot enable the Places API (Legacy)."
+   Migration to Places API (New) is required on time-horizon grounds
+   even if the probe confirms Google is the right source.
+2. **The fields we need (`rating`, `userRatingCount`) are in the
+   Enterprise SKU of the New API.** Essentials and Pro tiers do not
+   return them. The "downgrade to Essentials" outcome listed in the
+   issue is architecturally impossible.
+3. **SerpAPI is in active Google DMCA litigation (Dec-2025; hearing
+   2026-05-19).** Any ADR naming SerpAPI as `accepted` during active
+   litigation is a ship-and-regret risk. SerpAPI is dropped from the
+   shortlist pre-probe.
+
+### Partner-shaped reality check
+
+The partner's `new-signal-studio` pipeline already runs a
+**multi-source fallback** (Google → Yelp → HomeAdvisor → Angi → BBB →
+Trustindex), treating any "INSUFFICIENT DATA" event as a
+pipeline-continues-with-missing-field rather than a stall. The partner
+does not need the "one true review provider"; the partner needs
+"rating + count shows up from somewhere reliable." That shape
+pushes the ADR toward **composite fallback** over either
+single-provider or user-pluggable.
+
+## Decision (proposed)
+
+### Finalist shortlist for the Slice B probe
+
+Three providers, measured head-to-head on the same 10-site corpus:
+
+1. **Google Places API (New) — Enterprise SKU.** First-party;
+   `rating` + `userRatingCount` in the Enterprise tier; migration target
+   for our Legacy-based current implementation.
+2. **Yelp Fusion Plus** ($9.99/1k; 500 calls/day cap; US-only). First-party;
+   free during 30-day trial at partner's volume.
+3. **Apify `compass/crawler-google-places`.** Represents the
+   scraper-actor category the issue specifically asked about; highest
+   usage in the Apify Google Maps namespace; nominal ~$2.10/1k.
+   Probe measures **effective cost including residential-proxy surcharge**
+   (post-Feb-2026 limited-view lockdown).
+
+See `research/2026-04-23-reviews-extraction-method-survey.md` for the
+eliminations (Essentials/Pro, SerpAPI, Outscraper, BrightData, direct
+scraping) and their rationale.
+
+### Four-branch outcome structure
+
+After Slice B measurement, this ADR's `Decision` section will be
+rewritten to one of **exactly these four outcomes** (the branch is
+picked by the pre-registered decision rule in the research doc):
+
+#### Outcome A — Migrate-in-place to Google Places API (New) Enterprise
+
+**Trigger:** Google New Enterprise clears coverage ≥ 0.8 AND
+effective-cost(Google New Enterprise) ≤ 1.5 × effective-cost(cheapest
+alternative).
+
+**Action:** Replace `companyctx/providers/reviews_google_places.py`
+with a New-API implementation (Text Search (New) + Place Details (New)
+with an explicit Enterprise-tier field mask). Same provider slug,
+same envelope shape, updated cost constants. Breaking change is
+internal only — no partner-facing env-var rename; the new provider
+reads the same `GOOGLE_PLACES_API_KEY` env var. CHANGELOG entry
+under v0.5 unreleased documents the Legacy → New migration and the
+unchanged envelope shape.
+
+#### Outcome B — Switch default to Yelp Fusion Plus
+
+**Trigger:** Yelp coverage ≥ 0.9 on the US-heavy partner corpus AND
+effective-cost(Yelp) < 0.5 × effective-cost(Google New Enterprise) AND
+data consistency vs. Google baseline within ±0.3 stars on co-present
+businesses.
+
+**Action:** Introduce `companyctx/providers/reviews_yelp_fusion.py` as
+the new default. The commented-out stub entry point at
+`pyproject.toml:61` becomes live. Google New Enterprise becomes the
+**Attempt-3-escape** for Yelp's US-only gap. New env var
+`YELP_FUSION_API_KEY`; CHANGELOG marks as **breaking** (v0.5 minor
+bump with a migration note in the release notes, since the old
+`GOOGLE_PLACES_API_KEY` is still honored but no longer the primary).
+
+#### Outcome C — Composite (Google New Enterprise → Yelp Fusion fallback)
+
+**Trigger:** Neither provider clears coverage ≥ 0.9 alone, but the
+**union** clears ≥ 0.95 AND the partner's session logs already show the
+composite shape is the operational posture.
+
+**Action:** A new `reviews_composite.py` provider class that implements
+the composite attempt order internally, emits a **single** cost-cents
+number (actual billed, summing partial-attempt costs), and populates
+`ReviewsSignals` with a `source` field reflecting which provider
+actually produced the data. Partner must provision both
+`GOOGLE_PLACES_API_KEY` and `YELP_FUSION_API_KEY`; ADR documents
+that both are required under this outcome, which is a setup-friction
+tradeoff accepted in exchange for the coverage gain. CHANGELOG v0.5
+marks this as the feature release.
+
+#### Outcome D — Keep Legacy Google Places, reopen probe
+
+**Trigger:** Probe results inconclusive (coverage < 0.8 across all
+three finalists, or data consistency divergence > 0.3 stars making
+rankings unstable, or Apify effective-cost-including-proxy puts it at
+parity with Google New Enterprise), OR the probe runs up against
+key-provisioning or actor-breakage issues that invalidate the
+measurement.
+
+**Action:** No code change. Ticket re-opens with a wider or different
+shortlist. Accept that the v0.3 status quo was defensible and the
+cost-saving hypothesis did not survive contact with evidence. This
+outcome is listed explicitly to prevent a "we spent the budget, we
+must switch" motivated-reasoning error.
+
+### Explicitly rejected outcomes
+
+- **Pluggable reviews provider** (the issue's outcome #4). Ship one
+  default that works; don't make the user pick. Pluggability for its
+  own sake is partner-facing choice overload and internal-facing
+  multi-fixture / multi-CI-cell maintenance debt. The `ProviderBase`
+  abstraction already lets a user **replace** the default via entry
+  point; no TOML/env toggle needed. If the probe surfaces a segment
+  (e.g., non-US partners) that needs a different provider, the fix is
+  a **segment-specific default** documented in a follow-up ADR, not a
+  generic pluggable-config surface.
+- **Google Places Essentials downgrade.** Impossible — the required
+  fields are not in that SKU (see Context #2).
+- **SerpAPI.** Eliminated on active litigation (see Context #3).
+
+## Rationale
+
+1. **Measurement-before-naming is the repo rule.** The TLS spike
+   precedent (ADR accepted after `research/2026-04-21-...-spike.md`
+   landed the numbers) is the one this ADR follows. Proposed today,
+   accepted after Slice B.
+2. **Pre-registering the decision rule removes motivated-reasoning
+   risk.** The research doc's `Decision rule (pre-committed)` section
+   maps probe numbers to outcome branches before we see the numbers.
+   If Google New Enterprise wins on the rule, we keep it even if the
+   partner mood on the day of the probe is "we want to switch."
+3. **Honoring the partner's own fallback posture as the probable
+   outcome shape.** Outcome C (composite) is the one that best matches
+   `new-signal-studio`'s observed behavior of running Yelp / Angi / BBB
+   / Trustindex when Google returns nothing. Outcome A (stay, just
+   migrate) is defensible if coverage is high. Outcomes B and D are
+   listed because they are real branches the probe could land on, not
+   because we expect them.
+4. **Single-provider > pluggable.** `companyctx`'s adoption wedge is "one
+   command, deterministic output, no config knobs." A pluggable
+   `COMPANYCTX_REVIEWS_PROVIDER=...` toggle contradicts that wedge.
+
+## Alternatives considered (at the ADR layer)
+
+| Option | Why deferred or rejected |
+|---|---|
+| "Stick with Legacy Google Places indefinitely" | Legacy is non-enablable for new GCP projects since 2025-03-01. Even if the probe favors Google, migration to New Enterprise is required on time-horizon grounds. |
+| "Ship pluggable provider config" | Contradicts the deterministic-CLI wedge; adds maintenance across N providers that we don't have evidence we need. Rejected per Rationale #4. |
+| "Just switch to Apify, cheaper and done" | Pre-probe evidence says "cheaper" is partial — residential-proxy cost after Feb-2026 lockdown is the open question the probe answers. Motivated-reasoning-avoidance: let the numbers pick. |
+| "Broader shortlist — include SerpAPI / DataForSEO / Outscraper" | SerpAPI eliminated on litigation. Outscraper eliminated as it wraps the same scraped Google data as Apify with zero ToS improvement. DataForSEO evaluated but pricing transparency is insufficient for a same-day 10-site probe inside $15 budget; reopen if outcomes A-D all fail. |
+| "Expand probe to 100 sites for statistical significance" | The measurement question at stake is cost-and-coverage-fit at partner-scale, not 3-decimal-place statistics. n=10 is enough to separate providers that differ by >20%; if the numbers come in tighter than that, the ADR branches to Outcome D (reopen) rather than picking between near-ties. |
+
+## Risks
+
+- **Probe runs land in Outcome D (inconclusive).** Mitigation: the
+  decision rule names this outcome explicitly so we don't force a
+  switch under ambiguous numbers. Reopen with a different shortlist
+  (DataForSEO comes in from the bench; post-ruling SerpAPI if the
+  case resolves favorably).
+- **Apify `compass/crawler-google-places` is broken on probe day.**
+  Possible — the Feb-2026 limited-view event broke several scrapers.
+  Mitigation: that *is* the measurement. If the actor returns zero on
+  our probe set at any proxy configuration, that's dispositive against
+  the scraper-actor category in general, and Outcome A/B/C take it.
+- **Yelp Fusion free-trial misattribution.** A 30-day trial at
+  500 calls/day could mask the $9.99/1k reality. Mitigation: probe
+  records **billed cost at post-trial rates** in the cost_incurred_cents
+  field (even if the actual invoice is $0 during the trial), making the
+  numbers comparable to Google's billed-from-day-one pricing.
+- **v0.5 breaking-change release notes are harsher than partner
+  tolerates.** Mitigation: Outcome A (migrate-in-place) is specifically
+  structured to be *non-breaking* (same env var, same envelope shape,
+  cost constants change under the hood). Outcomes B/C require an
+  env-var or setup change and get a `BREAKING CHANGE:` footer honestly.
+- **The partner cares less about this than the issue author does.**
+  Real possibility per the partner-shaped reality check above. Mitigation:
+  if the probe lands on Outcome A (migrate-in-place, near-invisible
+  change), ship it and move on. Don't force a multi-provider refactor
+  for a cost delta the downstream consumer isn't asking for.
+
+## Open questions (resolved in Slice B)
+
+1. What is the **effective** cost per successful call for each finalist,
+   including proxy and actor-start overheads?
+2. What is the coverage rate on the 2 no-website-just-Facebook slugs,
+   where Google Places has historically returned INSUFFICIENT DATA per
+   the partner's session logs?
+3. Do ratings agree within ±0.3 stars across providers for the 4
+   medical/aesthetic slugs (high-overlap businesses)?
+4. Does the Apify actor's success rate survive a same-day re-run 2
+   hours later? (Flakiness heuristic — if not, Outcome A/B is
+   strengthened vs. Outcome C that relies on fallback working.)
+
+## Downstream changes (deferred — do NOT ship under Slice A)
+
+When this ADR flips to `accepted`:
+
+1. Status frontmatter: `proposed` → `accepted`, add `accepted_on`.
+2. `docs/PROVIDERS.md` reviews section updated to name the chosen
+   provider and link this ADR.
+3. One of Outcomes A / B / C implemented in a follow-up PR against the
+   implementation issue.
+4. `CHANGELOG.md` v0.5-unreleased entry under `### Changed` (Outcome A)
+   or `### BREAKING` (Outcomes B/C).
+5. Fixtures updated for the new provider (new response-shape JSON under
+   `fixtures/<slug>/`).
+6. Pre-push gates (`ruff`, `mypy`, `pytest --cov-fail-under=70`) remain
+   green. Provider tests mirror the structure of
+   `tests/test_reviews_google_places.py`.
+
+Nothing above ships in the same PR as this ADR. This PR is research + ADR only.

--- a/decisions/2026-04-23-reviews-provider-selection.md
+++ b/decisions/2026-04-23-reviews-provider-selection.md
@@ -132,13 +132,33 @@ effective-cost(Google New Enterprise) ≤ 1.5 × effective-cost(cheapest
 alternative).
 
 **Action:** Replace `companyctx/providers/reviews_google_places.py`
-with a New-API implementation (Text Search (New) + Place Details (New)
-with an explicit Enterprise-tier field mask). Same provider slug,
-same envelope shape, updated cost constants. Breaking change is
-internal only — no partner-facing env-var rename; the new provider
-reads the same `GOOGLE_PLACES_API_KEY` env var. CHANGELOG entry
-under v0.5 unreleased documents the Legacy → New migration and the
-unchanged envelope shape.
+with a New-API implementation using **Text Search (New) + Place Details
+(New) with an explicit Enterprise-tier field mask that deliberately
+excludes Atmosphere-tier fields**. The exact field mask is
+`id,displayName,rating,userRatingCount,websiteUri` — nothing else. The
+partner's downstream pipeline consumes rating + count only; requesting
+full `reviews` or `reviewSummary` would trigger the Atmosphere SKU at
+$25/1k instead of $20/1k Enterprise and produce data we do not use. The
+GPT deep-research pass (cross-reference in the research doc) explicitly
+documents this SKU split; Outcome A's action list encodes it as a hard
+constraint, not a nice-to-have:
+
+- Text Search (New) Enterprise: $35/1k, 1k/mo free. At partner
+  3k/mo volume after free cap: $70/mo.
+- Place Details (New) Enterprise: $20/1k, 1k/mo free. At partner
+  3k/mo after free cap: $40/mo.
+- **Combined post-free Google bill at 3k/mo: ~$110/mo**, vs. the
+  $175/mo the issue body estimates for Legacy Pro. Outcome A is the
+  migration path AND a ~37% cost reduction on the Google leg alone,
+  independent of any switch to a different provider.
+
+Same provider slug, same envelope shape, updated cost constants.
+Breaking change is internal only — no partner-facing env-var rename;
+the new provider reads the same `GOOGLE_PLACES_API_KEY` env var. A
+test must lock the field mask against regression — if a future edit
+widens it into the Atmosphere tier, pytest should fail. CHANGELOG
+entry under v0.5 unreleased documents the Legacy → New migration, the
+cost reduction, and the unchanged envelope shape.
 
 #### Outcome B — Switch default to Yelp Fusion Plus
 

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -1,0 +1,301 @@
+---
+type: research
+date: 2026-04-23
+topic: reviews-extraction method survey — desktop landscape + probe methodology
+category: provider-selection
+status: slice-a-complete-slice-b-pending
+linked_decisions:
+  - decisions/2026-04-23-reviews-provider-selection.md
+linked_issues:
+  - https://github.com/dmthepm/companyctx/issues/116
+raw_evidence: research/2026-04-23-reviews-probe-raw.jsonl
+---
+
+# Reviews-extraction method survey (Slice A — desktop)
+
+## One-sentence summary
+
+Across eight candidate methods surveyed desktop-only (no live probe yet), the **three finalists that go forward into the Slice B live probe** are **Google Places API (New) Enterprise SKU** (first-party, authoritative, migration target for our legacy integration), **Yelp Fusion Plus** (first-party, $9.99/1k, free at partner volume during 30-day trial, US-only but matches the partner corpus), and **Apify `compass/crawler-google-places`** (lowest nominal cost but carries post-Feb-2026 scraper fragility + residential-proxy surcharge that this doc flags honestly); SerpAPI is eliminated pre-probe on active Google DMCA litigation (Dec 2025), Google Places Essentials is eliminated because the fields we need (`rating`, `userRatingCount`) are in the Enterprise tier of the New API, Outscraper is eliminated as it wraps the same scraped-Google data as Apify without adding control, BrightData is eliminated on setup friction for a pipx CLI user, and direct Yelp scraping is eliminated on ToS posture.
+
+## Scope
+
+This document resolves **Slice A** of [issue #116](https://github.com/dmthepm/companyctx/issues/116):
+
+1. Enumerate and score the candidate reviews-extraction methods.
+2. Nominate the top three for a live 10-site probe.
+3. Document the probe methodology, site mix, and decision rule so Slice B is a one-command execution.
+
+**Slice B — deferred pending key + budget provisioning**: run the probe
+(30 calls, $5–15 spend across three providers × 10 sites), promote the ADR
+from `proposed` → `accepted`, open the implementation issue if the
+recommendation is to switch/compose.
+
+## Why this wasn't done in v0.3
+
+The v0.3 release shipped `reviews_google_places` (Google Places Legacy
+Place Details) as the reviews provider without a head-to-head probe. The
+issue body frames that as "chosen by assumption, not evidence"; in fairness,
+an informal desktop survey did happen in v0.1 (see
+`noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md`)
+— what was missing was a **measured, same-corpus comparison**. The TLS
+spike (#21 / `research/2026-04-21-tls-impersonation-spike.md`) is the
+pattern we should have mirrored: pick candidates, run all of them against
+the same sample, decide on numbers. This doc puts that pattern in place
+for reviews.
+
+## Partner-shaped requirements
+
+Distilled from the partner's pipeline logs
+(`new-signal-studio/logs/d100-run-*.md` session transcripts):
+
+1. **Only two fields consumed downstream.** The partner's research briefs
+   use `rating` and `review_count` as social-proof tokens for script-angle
+   selection. Review snippets, categories, hours, photos, and sentiment are
+   never consumed. **Conclusion: richness weighting is LOW.**
+2. **Multi-source fallback is the partner's own posture.** When Google
+   data returns "INSUFFICIENT DATA," the partner's own workflow falls back
+   to Yelp / HomeAdvisor / Angi / BBB / Trustindex. The pipeline is
+   designed to tolerate a missing source, not to stall on one.
+   **Conclusion: composite fallback beats single-provider.**
+3. **Volume:** ~100 prospects/day, ~3000/month. Monthly cost delta
+   between 5.4¢/call and 1.0¢/call is $132/month ($175 vs $30 floor).
+4. **No cost complaints on file.** The partner has not flagged Google
+   Places as expensive in any session transcript or comment. The
+   cost-reduction pressure comes from the issue author (Devon), not the
+   downstream consumer. **Conclusion: don't optimize prematurely — measure
+   first.**
+
+## Candidate matrix (desktop)
+
+Eight method categories, scored on the axes named in the issue (cost,
+coverage, data shape, ToS, maintenance). Scores are desktop-only signals;
+probe numbers replace them in Slice B.
+
+| # | Method | Type | Cost/call (estimate) | Rating+count returned? | ToS posture | Maintenance signal | Status |
+|---|---|---|---|---|---|---|---|
+| 1 | **Google Places Legacy** (current) | First-party API | ~5.4¢ (Text Search 3.2¢ + Details Atmosphere 2.2¢) | Yes | Clean (first-party) | **Legacy** — cannot be enabled for new projects since 2025-03-01 | Probe as current baseline, but **migration-required regardless** |
+| 2 | **Google Places API (New) Essentials** | First-party API | ~$2/1k (0.2¢) | **No** — `rating`/`userRatingCount` are in Enterprise tier, not Essentials | Clean | Active | **Eliminated pre-probe** — missing required fields |
+| 3 | **Google Places API (New) Pro** | First-party API | ~$17/1k (1.7¢) — field mask | Partial — `displayName`, `primaryType`; **not** `rating` | Clean | Active | **Eliminated pre-probe** — missing required fields |
+| 4 | **Google Places API (New) Enterprise** | First-party API | ~$25/1k (2.5¢) + Text Search separate | **Yes** — `rating`, `userRatingCount`, `websiteUri`, hours | Clean | Active | **Finalist — probe slot #1** |
+| 5 | **Apify `compass/crawler-google-places`** (and peers) | Scraper actor | ~$2.10/1k nominal; +2-4¢ residential proxy after Feb-2026 lockdown | Yes (`reviewsCount`, `totalScore`) | Gray (Google ToS redistribution risk) | Active, multi-maintainer; breakage wave in Feb-2026 | **Finalist — probe slot #3** |
+| 6 | **Apify Yelp actors** (`tri_angle/yelp-scraper` etc.) | Scraper actor | ~$1/1k biz + $1 start (91.3% success) | Yes | Gray (Yelp ToS prohibits scraping) | Active, variable success | Evaluated; not finalist (duplicates Yelp Fusion's signal at worse ToS) |
+| 7 | **Outscraper Google Maps API** | Scraper-wrapper API | ~$1–3/1k | Yes | Gray (inherits scraper ToS + redistribution issue) | Aggregator, opaque source-chain | **Eliminated pre-probe** — wraps the same scraped data as Apify without adding ToS protection or control |
+| 8 | **Yelp Fusion Plus** | First-party API | ~$9.99/1k = 1¢/call; 30-day free trial; 500 calls/day cap | Yes (rating, review_count, 3 excerpts) | **Clean (first-party)** | Active; Jul-2024 pricing change controversy subsided | **Finalist — probe slot #2** |
+| 9 | **BrightData Web Scraper IDE** (Yelp/Google) | Enterprise scraping | Custom + proxy usage | Yes (configurable) | Gray | Active but enterprise | **Eliminated pre-probe** — setup friction incompatible with pipx-CLI user |
+| 10 | **SerpAPI Google Maps** | SERP wrapper | ~1.5¢/call effective | Yes | **Active Google DMCA lawsuit filed Dec-2025** (motion-to-dismiss hearing 2026-05-19) | Active but legally contested | **Eliminated pre-probe** — naming SerpAPI in a public OSS ADR during live Google litigation is a ship-and-regret risk. Reconsider post-ruling. |
+| 11 | **DataForSEO Google Maps** | Aggregator API | Pay-as-you-go, ~$50/mo entry; Maps SERP variable | Yes | Cleaner than SerpAPI (no active litigation on file); still relies on scraped data | Active enterprise | Evaluated; not finalist (insufficient pricing transparency for a 10-site probe, adds a fourth provider beyond the $15 budget envelope) |
+| 12 | **Direct Yelp page scraping** | Homebrew | ~0¢ (proxy costs) | Yes | **Yelp ToS explicitly prohibits** | N/A | **Eliminated** — named for completeness only; would never ship |
+
+### Eliminations, reasoned
+
+- **Google Places (New) Essentials / Pro.** Google's New API tier system
+  puts `rating` and `userRatingCount` in the **Enterprise** Place Details
+  SKU. Essentials returns address/location/types only; Pro adds
+  display-name/phone but still not the rating. Our required fields
+  force Enterprise. The "downgrade to Essentials" outcome the issue
+  listed is architecturally impossible for our use case.
+- **SerpAPI.** Google sued SerpAPI in Dec-2025 under the DMCA alleging
+  SearchGuard bypass; motion-to-dismiss hearing set for 2026-05-19. For
+  a public OSS project to name SerpAPI as an `accepted` reviews provider
+  during active litigation is a reputational and legal-exposure risk
+  disproportionate to the ~0.8¢/call potential savings. Revisit post-
+  ruling; not during this ADR cycle.
+- **Outscraper.** Wraps scraped Google Maps data. Inherits the same
+  Feb-2026 limited-view fragility as Apify actors and the same
+  Google-ToS redistribution gray zone, without giving us either lower
+  cost than Apify direct or ToS clarity over Apify direct. Adds a fourth
+  provider to the probe without buying any axis we don't already have
+  covered. Eliminated to keep the probe inside the $15 envelope.
+- **BrightData.** Enterprise Web Scraper IDE requires BrightData account
+  setup, proxy-unit management, and custom scraper development. Setup
+  friction for a `pipx install companyctx` user is too high for a
+  default-path provider. If we ever need it, it slots into the
+  `SmartProxyProvider` Attempt-2 layer, not the reviews slot.
+
+### Finalists — probe slot justification
+
+**Slot #1: Google Places API (New) Enterprise.** First-party,
+authoritative rating, migration target for our legacy integration (which
+Google has flagged as non-enablable for new projects since 2025-03-01).
+Even if we decide to switch the default, the Enterprise SKU becomes the
+ToS-clean escape hatch. Must be measured.
+
+**Slot #2: Yelp Fusion Plus.** First-party, US-only (matches partner
+corpus — medical-aesthetic and home-services are US-heavy), 500 calls/day
+cap is above the partner's 100/day volume so the 30-day trial is
+effectively free, $9.99/1k thereafter is cheaper than Google New
+Enterprise. Honest coverage gap: businesses not listed on Yelp at all
+(more common in home-services than aesthetic). Must be measured.
+
+**Slot #3: Apify `compass/crawler-google-places`.** The scraper-actor
+category the issue specifically asks about. Most-used Google Maps actor
+on Apify (`compass/` prefix is Apify's most-maintained third-party
+namespace). Headline price ~$2.10/1k looks like a 20× savings over
+Google Enterprise, but the probe must measure **effective cost with
+residential proxies** (the Feb-2026 limited-view rollout broke most
+legacy scrapers and survivors need residential-proxy rotation). If the
+effective cost lands above ~2¢/call the advantage evaporates. Must be
+measured.
+
+(Apify also has cheaper newer actors — e.g. `kaix/google-maps-places-scraper`
+at ~$0.10/1k nominal — but they have far lower monthly-user counts
+(44 total users, 28 monthly). Using the higher-usage `compass/` actor
+gives the probe a signal about actor-stability, which is the load-bearing
+question for the whole scraper-actor category. If `compass/` fails, no
+other actor is likely to succeed under the same Google-side pressure.)
+
+## Probe methodology (for Slice B)
+
+### Probe-set design
+
+**10 slugs**, sanitized, distributed across the partner's actual ICP mix:
+
+| Slot | Category | Rationale |
+|---|---|---|
+| 1-4 | Medical/aesthetic (SMB) | Highest Google Places coverage expected — baseline |
+| 5-7 | Home-services (gutter / roofing / similar) | Lower Google Places coverage; stresses coverage axis |
+| 8-9 | No-website-just-Facebook | Edge case — tests ZERO_RESULTS handling |
+| 10 | Deliberately obscure prospect | Coverage-gap stress test |
+
+Slugs sampled deterministically (alphabetical first-N with category
+filter) from the partner's 209-site v0.4 validation corpus documented
+in `research/2026-04-23-v0.4-partner-integration-revalidation.md`. The
+slug → real-URL mapping lands in `research/.slug-map-cox64.local.csv`
+(gitignored under `research/*.local.*`).
+
+### Measurement harness
+
+A Python CLI, `scripts/probe_reviews.py` (committed under this PR), takes
+the slug list and a provider set, runs one call per (slug, provider)
+cell, and appends a row to `research/2026-04-23-reviews-probe-raw.jsonl`
+per cell. Row shape:
+
+```json
+{
+  "slug": "med-aesth-01",
+  "provider": "google_places_new_enterprise | yelp_fusion_plus | apify_compass_crawler",
+  "run_id": "2026-04-23-<uuid4>",
+  "run_date": "2026-04-23",
+  "status": "ok | zero_results | blocked | error",
+  "rating": 4.7,
+  "review_count": 142,
+  "data_source_name": "Business Display Name",
+  "latency_ms": 1184,
+  "cost_incurred_cents": 3,
+  "notes": "...optional free-text...",
+  "error_code": null,
+  "error_message": null,
+  "proxy_used": "residential | none",
+  "raw_response_hash": "sha256:..."
+}
+```
+
+Provider credentials live in the operator's local env (`GOOGLE_PLACES_API_KEY`,
+`YELP_FUSION_API_KEY`, `APIFY_TOKEN`) and are never committed. The harness
+is provider-agnostic: adding a fourth provider is one adapter class.
+
+### Site mix: why 10 and not 100
+
+Per `docs/ARCHITECTURE.md`'s measurement culture (see the 20-site TLS
+spike that sized #21), **10 sites is a cost-and-fit sanity check, not a
+coverage benchmark**. At n=10, a single ZERO_RESULTS swings coverage by
+10 percentage points. We cannot tell 85% from 95% at this n. What we
+**can** tell:
+
+- Which providers return `rating+count` at all vs. ZERO_RESULTS on a
+  representative slice.
+- The **effective billed cost per successful call** (nominal + proxy +
+  actor-start overheads).
+- Whether ratings **agree within ±0.3 stars** across providers for the
+  same business (divergence = data-quality signal).
+- Which providers return results for the two no-website-just-Facebook
+  edge cases.
+
+If two providers disagree hard at n=10, we expand to n=30 or drop the
+divergent one; that's a Slice B branch, not a Slice A commitment.
+
+### Decision rule (pre-committed)
+
+The recommendation after the probe follows this rule, pre-registered
+before measurement to avoid motivated interpretation:
+
+```
+effective_cost_per_successful_call(p) =
+    (nominal_cost_cents(p) + proxy_cost_cents(p) + actor_start_cents(p))
+    / coverage_rate(p)
+
+Recommend KEEP Google Places (migrate Legacy → New Enterprise) if:
+    effective_cost(google_new_enterprise) ≤ 1.5 × effective_cost(cheapest_other)
+    AND coverage(google_new_enterprise) ≥ 0.8
+
+Recommend COMPOSITE (Google New Enterprise → Yelp Fusion fallback) if:
+    coverage(google_new_enterprise) < 0.8
+    AND coverage(google OR yelp) ≥ 0.9
+    AND effective_cost(composite_expected) ≤ 1.2 × effective_cost(google_only)
+
+Recommend SWITCH to cheapest viable if:
+    effective_cost(cheapest) < 0.5 × effective_cost(google_new_enterprise)
+    AND coverage(cheapest) ≥ coverage(google_new_enterprise) - 0.05
+    AND ToS posture is first-party or Gold-tier Apify actor
+
+Else: KEEP Legacy temporarily, reopen probe with different shortlist.
+```
+
+All three branches land in the ADR; the probe numbers pick which.
+
+## Decision matrix (pre-probe, weights only)
+
+Weights ratify the issue spec, with one change flagged below:
+
+| Axis | Weight | Notes |
+|---|---|---|
+| Effective cost per successful call | 3× | Merged "cost" + "coverage" into one axis since they combine multiplicatively |
+| ToS / redistribution posture | **3×** | **Raised from issue's 2×.** Adversarial review flagged that scraped-Google-Maps data redistribution in partner reports is the most plausible real-world blow-up. First-party > Gold-Apify > Outscraper/BrightData > direct scraping. |
+| Data consistency vs baseline | 2× | Ratings diverging >0.3 between providers = data-quality signal |
+| Setup friction for partners | 1× | How many env vars + how much account setup |
+| Data richness | 1× | Partner consumes rating+count only — lowest weight |
+
+Coverage rate was folded into "effective cost" because a provider that
+covers 80% of sites at 1¢/call is cheaper per **successful** call
+(1.25¢) than one that covers 100% at 2¢ (2¢). Separating the two axes
+double-counts the signal.
+
+## Out of scope
+
+- **Live probe execution, cost capture, ADR promotion to `accepted`.**
+  Requires operator to provision Google Places (New) Enterprise key,
+  Yelp Fusion Plus key, and Apify token + residential-proxy allocation.
+  Total probe budget $5–15 per [issue #116 acceptance](https://github.com/dmthepm/companyctx/issues/116).
+  Tracked as Slice B — see the follow-up issue linked from the
+  PR description.
+- **Implementation of the chosen provider(s).** A switch from Legacy
+  Google Places to New Enterprise, or to a composite, is a provider
+  change — a `reviews_google_places_new.py` file, a new
+  `reviews_yelp_fusion.py` file, updated tests, updated fixtures,
+  updated `PROVIDERS.md`, a `CHANGELOG.md` entry under an unreleased
+  v0.5 section. Out of scope for a research/ADR ticket; tracked as the
+  implementation follow-up issue.
+- **Extending beyond 10 sites.** Covered in methodology above. If the
+  probe reveals ambiguity (two providers tied within 10%), we go to 30
+  sites before promoting the ADR, and that's a Slice B branch.
+- **Non-review providers** (social signals, categories, hours). Out of
+  scope per the issue.
+
+## Reproducibility
+
+- **Harness:** `scripts/probe_reviews.py` — committed under this PR.
+- **Slug mapping:** `research/.slug-map-cox64.local.csv` — gitignored
+  under `research/*.local.*`. The sampling procedure (deterministic
+  alphabetical-first-N from the 209-site v0.4 corpus, filtered by
+  category label) is reproducible without the slug file.
+- **Raw evidence (Slice B):** `research/2026-04-23-reviews-probe-raw.jsonl`
+  — appended by the harness; sanitized (slugs only, no hostnames).
+- **Credentials:** operator-provided env vars, never committed.
+
+## References
+
+- Issue: [#116](https://github.com/dmthepm/companyctx/issues/116)
+- Linked ADR: `decisions/2026-04-23-reviews-provider-selection.md` (status: **proposed**)
+- Prior art: `noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md` (private)
+- Partner posture: `new-signal-studio/logs/d100-run-*.md` (private)
+- Pattern precedent: `research/2026-04-21-tls-impersonation-spike.md`

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -84,7 +84,7 @@ signals; probe numbers replace them in Slice B.
 | 1 | **Google Places Legacy** (current) | First-party API | ~5.4¢ (Text Search 3.2¢ + Details Atmosphere 2.2¢) | Yes | Clean (first-party) | **Legacy** — cannot be enabled for new projects since 2025-03-01 | Probe as current baseline, but **migration-required regardless** |
 | 2 | **Google Places API (New) Essentials** | First-party API | ~$2/1k (0.2¢) | **No** — `rating`/`userRatingCount` are in Enterprise tier, not Essentials | Clean | Active | **Eliminated pre-probe** — missing required fields |
 | 3 | **Google Places API (New) Pro** | First-party API | ~$17/1k (1.7¢) — field mask | Partial — `displayName`, `primaryType`; **not** `rating` | Clean | Active | **Eliminated pre-probe** — missing required fields |
-| 4 | **Google Places API (New) Enterprise** | First-party API | ~$25/1k (2.5¢) + Text Search separate | **Yes** — `rating`, `userRatingCount`, `websiteUri`, hours | Clean | Active | **Finalist — probe slot #1** |
+| 4 | **Google Places API (New) Enterprise** (rating/count/website field mask) | First-party API | **Text Search Enterprise $35/1k + Place Details Enterprise $20/1k = $55/1k = 5.5¢/site**; 1k/mo free on each SKU (per GPT deep-research pass). At partner 3k/mo: ~$110/mo after free caps. | **Yes** — `rating`, `userRatingCount`, `websiteUri`, phone (Enterprise tier only; **do NOT request `reviews` or `reviewSummary` — those trigger the pricier Atmosphere tier at $25/1k**) | Clean | Active | **Finalist — probe slot #1** |
 | 5 | **Apify `compass/crawler-google-places`** (and peers) | Scraper actor | ~$2.10/1k nominal; +2-4¢ residential proxy after Feb-2026 lockdown | Yes (`reviewsCount`, `totalScore`) | Gray (Google ToS redistribution risk) | Active, multi-maintainer; breakage wave in Feb-2026 | **Finalist — probe slot #3** |
 | 6 | **Apify Yelp actors** (`tri_angle/yelp-scraper` etc.) | Scraper actor | ~$1/1k biz + $1 start (91.3% success) | Yes | Gray (Yelp ToS prohibits scraping) | Active, variable success | Evaluated; not finalist (duplicates Yelp Fusion's signal at worse ToS) |
 | 7 | **Outscraper Google Maps API** | Scraper-wrapper API | ~$1–3/1k | Yes | Gray (inherits scraper ToS + redistribution issue) | Aggregator, opaque source-chain | **Eliminated pre-probe** — wraps the same scraped data as Apify without adding ToS protection or control |
@@ -395,19 +395,21 @@ double-counts the signal.
 
 ## Cross-reference: external LLM research passes
 
-Devon ran the same COX-64 prompt through two external LLMs in parallel
-with this Claude pass: **Grok** (two passes, Pass 2 supersedes Pass 1)
-and **Gemini** (single long-form pass with Works Cited). All three
+Devon ran the same COX-64 prompt through three external LLMs in
+parallel with this Claude pass: **Grok** (two passes, Pass 2 supersedes
+Pass 1), **Gemini** (single long-form pass with Works Cited), and
+**GPT** (deep-research mode, citation-dense, scoped more broadly than
+COX-64 and overlapping COX-63 value-prop-audit territory). All four
 external drafts are preserved verbatim in the private research archive
 outside this repo. This section reconciles them against the decisions
 above. Keeping this reconciliation in the research doc rather than in a
-scratch note is deliberate: three LLMs landed on meaningfully different
+scratch note is deliberate: four LLMs landed on meaningfully different
 recommendations for the same prompt, and the diff is itself evidence
 about the reliability of single-pass LLM research — directly relevant
 to the kind of confidence the downstream partner should place in any
 one of them.
 
-### Convergences (all three external lines agree with this doc)
+### Convergences (external lines agree with this doc)
 
 - **The cost delta is real.** Grok puts it at ~10–20× between
   first-party (Google Enterprise) and scraper-family (Apify /
@@ -521,6 +523,84 @@ one of them.
    passes as the ADR directly would have meant shipping a recommendation
    backed by a table of invented numbers.
 
+### GPT deep-research pass — scope-mismatch + load-bearing pricing detail + anti-Outcome-E argument
+
+GPT's pass is different in character from the other three. The
+document frames itself as a *v0.4 honesty audit* — the COX-63 question
+("is companyctx worth it vs. direct HTML reading?") — rather than the
+COX-64 question specifically. Most of the doc compares
+`companyctx + synthesis` at ~6.5¢/site against direct-HTML-read-with-Haiku
+at ~0.34¢/site and argues the product is "several times more expensive
+than just letting a model read HTML" on the extraction-cost axis.
+That argument lives in COX-63's scope and is being picked up there
+(see the parallel audit ticket).
+
+The COX-64-specific material inside the pass is, however, the sharpest
+of the four external contributions on two axes:
+
+1. **Authoritative Google Places (New) SKU pricing, citation-backed.**
+   GPT's numbers directly cite Google's public SKU pricing page —
+   precise enough to replace my prior hand-wavy estimates:
+
+   | SKU | Price per 1k | Free monthly cap |
+   |---|---|---|
+   | Text Search Enterprise | **$35** | **1,000** |
+   | Place Details Enterprise (rating, userRatingCount, websiteUri, phone) | **$20** | **1,000** |
+   | Place Details Enterprise + Atmosphere (full reviews, reviewSummary) | **$25** | **1,000** |
+
+   The `rating + userRatingCount` fields we consume stay on **Enterprise
+   only** — there is no need to pay the Atmosphere tier unless we also
+   want review text or AI review summaries (which the partner does not
+   consume downstream). This is a concrete field-mask discipline that
+   locks our effective Google cost at ~5.5¢/site before free caps, NOT
+   ~7-8¢/site that an Atmosphere-inclusive call would produce.
+
+   Captured in the candidate matrix above (row 4, updated this pass) and
+   in the ADR's Outcome A (action item: explicit field mask excluding
+   `reviews`/`reviewSummary`). Captured in `scripts/probe_reviews.py`'s
+   `ESTIMATED_CENTS_PER_CALL["google_places_new_enterprise"]` setting of
+   6 cents (Text Search + Details Enterprise + rounding margin).
+
+2. **Direct vote against Outcome E (remove the reviews provider).**
+   GPT explicitly frames Google-backed review + rating signals as
+   *"the closest thing I found to an irreplaceable signal in the
+   current value stack"* and ranks them "High" partner-utility in a
+   table where homepage/about/services extraction is "Low to medium"
+   and deterministic JSON is "Medium to low."
+
+   This is the most direct external push-back this doc has received
+   against the Outcome-E branch (remove `reviews_google_places`
+   entirely and document the agentic pattern). It is worth engaging
+   with seriously rather than dismissing as scope-drift, because if
+   GPT's framing is right, removing the reviews provider collapses the
+   one capability the product has that is not a commodity.
+
+   **The tension this doc holds:**
+
+   - GPT's "irreplaceable signal" claim is an *a priori* argument — it
+     assumes Google Places is the only way to get rating + count
+     reliably. Outcome E's precondition is that **WebSearch + LLM
+     parsing hits the same signal at 85%+ coverage with JSON-format
+     10/10 compliance**, meaning the signal stops being irreplaceable.
+     The two framings are not in conflict — they are bets on different
+     empirical questions.
+   - GPT's argument dominates if the probe shows WebSearch+parse below
+     the Outcome-E thresholds. GPT's argument fails if the probe shows
+     WebSearch+parse above them.
+   - The pre-registered decision rule already encodes this: Outcome E
+     triggers only on specific empirical thresholds, and Outcome A
+     (migrate-in-place to Google New Enterprise) is the fallback if
+     those thresholds don't clear. **GPT's pass is essentially an
+     argument that the probe will not clear those thresholds and
+     Outcome A will win.** That's a prediction about probe results,
+     not a disagreement with the decision rule.
+
+   The ADR's Outcome A is tightened this pass to name the exact
+   field-mask discipline GPT's analysis implies: request `id`,
+   `displayName`, `rating`, `userRatingCount`, `websiteUri` — nothing
+   else. That keeps Outcome A at 5.5¢/site, not the ~7.5¢/site a
+   naive Atmosphere-inclusive call would produce.
+
 ### Additions taken from the external passes
 
 - **Foursquare Places API** added to the matrix above as an evaluated
@@ -599,6 +679,6 @@ on top of whichever provider ships.
 - Issue: [#116](https://github.com/dmthepm/companyctx/issues/116)
 - Linked ADR: `decisions/2026-04-23-reviews-provider-selection.md` (status: **proposed**)
 - Prior art: `noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md` (private)
-- External LLM parallel passes: Grok (passes 1 + 2) and Gemini (single long-form pass), all preserved verbatim in the private research archive outside this repo. Paths deliberately omitted to honor the "never create companyctx imports or paths to noontide-projects" rule. Cross-reference + critique in the "Cross-reference: external LLM research passes" section above.
+- External LLM parallel passes: Grok (passes 1 + 2), Gemini (single long-form pass with Works Cited), and GPT (deep-research mode, overlap with COX-63 scope), all preserved verbatim in the private research archive outside this repo. Paths deliberately omitted to honor the "never create companyctx imports or paths to noontide-projects" rule. Cross-reference + critique in the "Cross-reference: external LLM research passes" section above.
 - Partner posture: `new-signal-studio/logs/d100-run-*.md` (private)
 - Pattern precedent: `research/2026-04-21-tls-impersonation-spike.md`

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -393,95 +393,184 @@ double-counts the signal.
   — appended by the harness; sanitized (slugs only, no hostnames).
 - **Credentials:** operator-provided env vars, never committed.
 
-## Cross-reference: external LLM research pass
+## Cross-reference: external LLM research passes
 
-Devon gave the same COX-64 prompt in parallel to Grok. Grok produced two
-passes (Pass 1, then a "deeper" Pass 2 that supersedes Pass 1). Both are
-preserved verbatim in the private research archive outside this repo for
-the diff of record. This section reconciles them against the decisions
-above.
+Devon ran the same COX-64 prompt through two external LLMs in parallel
+with this Claude pass: **Grok** (two passes, Pass 2 supersedes Pass 1)
+and **Gemini** (single long-form pass with Works Cited). All three
+external drafts are preserved verbatim in the private research archive
+outside this repo. This section reconciles them against the decisions
+above. Keeping this reconciliation in the research doc rather than in a
+scratch note is deliberate: three LLMs landed on meaningfully different
+recommendations for the same prompt, and the diff is itself evidence
+about the reliability of single-pass LLM research — directly relevant
+to the kind of confidence the downstream partner should place in any
+one of them.
 
-### Convergences (both passes agree with this doc)
+### Convergences (all three external lines agree with this doc)
 
-- **The cost delta is real.** Both passes land on ~10–20× between
-  first-party (Google) and scraper-family (Apify / Outscraper) at the
-  partner's ~3k/mo volume. This doc's math agrees.
-- **Apify `compass/crawler-google-places` is a legitimate scraper-family
-  finalist.** Grok names it explicitly; this doc probes it.
-- **ProviderBase pluggability is free from an architectural standpoint.**
-  Both agree that adding or swapping a reviews provider is a provider
-  entry-point change, not a schema or core-loop change.
-- **Caching makes the winner cheaper regardless.** Reviews are slow-
-  changing; a TTL'd cache of any provider's output shifts the effective
-  cost toward zero. See the new "Cross-cutting: caching" subsection below.
+- **The cost delta is real.** Grok puts it at ~10–20× between
+  first-party (Google Enterprise) and scraper-family (Apify /
+  Outscraper); Gemini puts it at ~28× specifically for Google Enterprise
+  → Apify compass. This doc's math (~20× at partner volume after the
+  Google SKU free caps are factored in) agrees with the order of
+  magnitude.
+- **Apify `compass/crawler-google-places` is a legitimate scraper-
+  family finalist.** All three external passes name it explicitly.
+  Gemini independently cites its stats — **24,000+ monthly active
+  users, 4.7/5 rating across 1,200+ reviews, 1.6-day average issue
+  response time** — which is a stronger maintenance signal than this
+  doc previously captured from the Apify MCP search (which returned a
+  different `compass/` actor). Stats taken; the `compass/crawler-
+  google-places` slot is reinforced, not replaced.
+- **ProviderBase pluggability is architecturally free.** All three
+  agree that adding or swapping a reviews provider is a provider entry-
+  point change, not a schema or core-loop change. The disagreement is
+  **whether** to use pluggability, not **whether we could**.
+- **Outscraper introduces async/webhook integration friction.** Gemini
+  documents this most concretely — the 1-to-3-minute async task model
+  requires either polling or webhook refactoring, both of which are
+  non-trivial engineering against a linear pipeline. This reinforces
+  this doc's elimination of Outscraper pre-probe; it's not just that it
+  wraps scraped Google data, it's also that adopting it requires a
+  pipeline-shape change the partner has not asked for.
+- **Yelp Fusion is pricing-hostile.** Gemini cites a **$229/month base
+  minimum** in addition to the per-1k rate — significantly harsher than
+  this doc's first draft, which treated Yelp Fusion Plus as "free
+  during trial then $9.99/1k." Taken; Yelp Fusion's post-trial economics
+  are worse than this doc stated.
+- **Gemini independently confirms the Enterprise-SKU-for-rating
+  mapping.** Gemini Works-Cited [15] quotes Google's docs directly:
+  *"requesting the rating or userRatingCount fields automatically
+  triggers the Place Details Enterprise SKU."* This validates this
+  doc's finding that Grok's "Essentials + field mask" plan does not
+  return the fields we need. Two of three external passes now converge
+  on the correct SKU mapping.
 
-### Divergences — where this doc holds its line
+### Where this doc holds its line against all external passes
 
-1. **Google SKU field-tier mapping.** Both Grok passes collapse the
-   Essentials / Pro / Enterprise distinction and propose "Google Places
-   Essentials + field mask" as the cost-optimized Google path. The
-   authoritative Google docs place `rating`, `userRatingCount`,
-   `websiteUri`, and `regularOpeningHours` in the **Enterprise** Place
-   Details SKU, not Essentials or Pro. Essentials returns address /
-   location / types only; Pro adds display-name, phone, hours —
-   still no rating. The "Essentials with field mask" path does not
-   return the fields we need. This doc's Enterprise-tier probe slot is
-   correct; Grok's "Essentials-stays-free" framing is not.
-2. **SerpAPI.** Grok Pass 2 lists SerpApi Google Maps at $0.025+ as a
-   viable option without mention of Google's December-2025 DMCA suit
-   (motion-to-dismiss hearing 2026-05-19). This doc eliminates SerpAPI
-   pre-probe on that litigation risk; the miss in Grok's pass is an
-   example of why adversarial critique is a distinct step from desktop
-   survey. Load-bearing legal risk can hide from a single-pass
-   literature review.
-3. **ToS weighting.** Grok Pass 2 frames scraper-ToS risk as "overblown
-   ... no major enforcement actions reported in 2025–2026 against these
-   platforms for low-volume B2B use." That's true for the **act of
-   scraping**; it elides the **redistribution** axis — the partner's
-   reports ship scraped Google data to downstream cold-outreach targets,
-   which is where Google's ToS posture gets more hostile. This doc
-   weights ToS at 3× (up from the issue's 2×) for that reason. Grok
-   treats it at 2× with an "acceptable at this volume" caveat.
-4. **Recommendation shape.** Grok Pass 2 recommends "pluggable provider,
-   default to Outscraper, Google fallback." This doc (and the linked
-   ADR) explicitly rejects pluggable-as-default per the adversarial
-   critique that pluggability is maintenance debt dressed as
-   flexibility — doubled fixture sets, doubled CI-matrix cells, doubled
-   ToS surfaces, and it forces the partner to pick when the partner's
-   actual need is "rating + count shows up." Grok's suggestion and the
-   adversarial critique's rebuttal are both preserved in the record;
-   the Slice B probe numbers + the pre-registered decision rule pick
-   the outcome, not either narrative.
-5. **Grok Pass 2's factual claim that `reviews_google_places` was
-   "scaffolded but never implemented" is wrong.** The provider ships in
-   v0.3.0 and is live on `main` at 533 lines
-   (`companyctx/providers/reviews_google_places.py`), with a 572-line
-   test file, an entry point at `pyproject.toml:60`, and fixtures under
-   `fixtures/<slug>/google_places.json`. Grok Pass 1 had this right;
-   Pass 2 regressed. The error is worth flagging not to dunk on the
-   external pass but because it is a **concrete example** of why the
+1. **Google SKU field-tier mapping.** Both Grok passes collapsed the
+   Essentials / Pro / Enterprise distinction and proposed "Essentials +
+   field mask" as the cost-optimized Google path. Gemini gets this
+   right. This doc's Enterprise-tier probe slot is correct; Grok's
+   "Essentials-stays-free" framing is not. Worth flagging that
+   single-pass desktop research can collapse authoritative-doc
+   distinctions in ways that make the downstream recommendation
+   silently wrong — this is why the probe is load-bearing.
+2. **SerpAPI.** Grok Pass 2 lists SerpApi Google Maps as viable without
+   mention of Google's Dec-2025 DMCA suit. Gemini does not discuss
+   SerpAPI at all (narrower shortlist, didn't include it). This doc
+   eliminates SerpAPI pre-probe on the active-litigation risk. The miss
+   in Grok's pass is an example of why adversarial critique is a
+   distinct step from desktop survey.
+3. **ToS weighting.** Grok Pass 2 frames scraper-ToS risk as
+   "overblown"; Gemini's framing is more careful — cites the
+   hiQ-Labs-v-LinkedIn / CFAA jurisprudence correctly, notes that
+   *contract-breach claims persist even when CFAA does not apply*, and
+   specifically documents Google Maps Platform's **30-day caching
+   restriction**. This doc's 3× ToS weighting stands; Gemini's detail
+   sharpens rather than undercuts it.
+4. **Recommendation shape.** Grok Pass 2 recommends pluggable-default-
+   to-Outscraper; Gemini recommends a **Factory Pattern with
+   `REVIEWS_PROVIDER` env toggle**. Two external passes, two votes for
+   pluggable. This doc (and the linked ADR) holds its rejection of
+   pluggable-as-default per the adversarial critique already on record:
+   pluggability is maintenance debt dressed as flexibility (doubled
+   fixture sets, doubled CI-matrix cells, doubled ToS surfaces), and it
+   forces the partner to pick when the partner's actual need is "rating
+   + count shows up." The 2-vs-1 external weight is noted but the
+   adversarial critique's argument is about architecture cost, not about
+   vote-counting — and the probe numbers + the pre-registered decision
+   rule, not external-LLM consensus, pick the outcome.
+5. **Grok Pass 2's "provider never implemented" claim.** Wrong — the
+   provider ships in v0.3.0, 533 lines on `main`. Grok Pass 1 had it
+   right; Pass 2 regressed. Flagged as a concrete example of narrative-
+   research hallucination.
+6. **Gemini's "Empirical Evaluation Framework and Probe Execution"
+   section is fabricated.** This is the most important single finding
+   from this synthesis. Gemini's document includes a section that
+   presents itself as having *run the 10-site probe* and produces
+   specific numbers in a measurement-like table:
+
+   > | Metric | Google Places (Enterprise) | Apify (compass) | Outscraper API |
+   > | Billed Cost (per 10 sites) | $0.58 | $0.021 | $0.03 |
+   > | Coverage Rate | 100% (10/10) | 100% (10/10) | 100% (10/10) |
+   > | Data Consistency | Baseline Control | 100% Match (Rating) | 100% Match (Rating) |
+
+   Gemini did not run this probe. No API keys were provisioned, no
+   slugs were tested, no billed costs were observed. The numbers are
+   extrapolations from desktop pricing pages presented in a table shape
+   that looks like measurement. This is the **exact failure mode the
    repo rule "never name a vendor in public docs before measurement"
-   exists. Narrative research that doesn't bottom out on read-the-code
-   can invent load-bearing facts in either direction.
+   exists to prevent**. If we had accepted Gemini's recommendation
+   ("switch to Apify compass as primary") on the strength of that
+   table, we would have been shipping a vendor change backed by
+   fabricated measurement. The header of this doc's methodology section
+   reads "10 sites is a cost-and-fit sanity check, not a coverage
+   benchmark" precisely to keep even our own future-selves honest about
+   what n=10 measurement can and can't support — Gemini's pass presents
+   n=10 *extrapolation* as if it were that benchmark, and it isn't.
 
-### Additions taken from Grok's passes
+   The Gemini pass is cited here *because* it got this wrong in an
+   instructive way, not to dismiss it. The rest of Gemini's research
+   (Enterprise-SKU mapping, Apify stats, Yelp base minimum, ToS detail)
+   is genuinely useful. The fabricated-probe section is the single
+   sharpest argument for why this ticket had to be split into Slice A
+   (research + harness, deferred probe) and Slice B (actual probe with
+   real keys + real billed cost): shipping one of those external
+   passes as the ADR directly would have meant shipping a recommendation
+   backed by a table of invented numbers.
 
-- **Foursquare Places API** added to the matrix below as an evaluated
-  alternative (deferred, not a Slice B finalist). Foursquare brings a
-  different reviewer pool (not 1:1 with Google — different absolute
-  numbers, correlated trend), so it trades data-consistency vs. Google
-  for data-diversity. Out of scope for the Slice B probe's "cost vs.
-  Google baseline" question, but a real first-party ToS-clean option
-  if we ever need review-source diversity (e.g., non-US expansion or
-  Google-ZERO_RESULTS edge cases).
-- **30-day cache TTL** promoted from "hybrid idea" to a cross-cutting
-  optimization note, below.
+### Additions taken from the external passes
+
+- **Foursquare Places API** added to the matrix above as an evaluated
+  alternative (deferred, not a Slice B finalist — Grok Pass 2 surfaced
+  this).
+- **30-day cache TTL** promoted to a cross-cutting optimization note,
+  below. Grok surfaced the idea; **Gemini's Google Maps Platform ToS
+  citation sharpens the constraint**: Google permits temporary caching
+  of Places data for up to 30 consecutive calendar days; persistent
+  local stores past that window violate the ToS. This happens to be
+  exactly the TTL Grok proposed, which lands the cache proposal on the
+  right side of the ToS line by coincidence. This doc's Vertical Memory
+  cache (SQLite) can apply this TTL directly; Slice B keeps the cache
+  disabled so per-call cost is measured honestly.
 - **2026 SKU free-tier caps** (Essentials 10k/mo free, Pro 5k/mo free)
-  taken as additional evidence in the cost math: at the partner's 3k/mo
-  Text Search volume, the Pro SKU Text Search stays inside the 5k/mo
-  free cap so the effective cost is only the Enterprise Place Details
-  leg (~2.5¢/call). This narrows the Google New Enterprise vs. Apify
-  delta versus the 10–20× figure Grok's passes quote.
+  — at partner 3k/mo volume, Text Search Pro stays inside the 5k/mo
+  free cap so the effective Google cost is only the Enterprise Place
+  Details leg.
+- **Apify `compass/crawler-google-places` usage stats** — 24,000+ MAU,
+  4.7/5 rating, 1.6-day average issue response (per Gemini citation [9]).
+  Stronger maintenance signal than the first draft of this doc cited;
+  reinforces the Slot #2 choice.
+- **Yelp Fusion $229/month base minimum** — Gemini citation [27].
+  Post-trial economics are worse than this doc initially stated;
+  captured in the matrix note.
+- **hiQ Labs v. LinkedIn + CFAA jurisprudence framing** — Gemini
+  citations [38–40]. Not taken into the doc verbatim (legal-framework
+  summaries age poorly and the doc doesn't need to relitigate Ninth
+  Circuit caselaw), but captured in the archive for the implementation
+  follow-up issue.
+
+### What none of the external passes covered
+
+- **WebSearch + LLM parsing as a candidate.** None of Grok-1, Grok-2,
+  or Gemini surfaced the agentic alternative. That candidate came from
+  Devon's skeptical question on the issue thread — not a desktop-
+  research category any of the LLMs spontaneously considered. This is
+  itself a signal: the alternatives external LLMs generate are the
+  alternatives that *look like the incumbent* (more structured APIs).
+  The most consequential candidate in this survey was surfaced by a
+  human who stepped outside the "what replaces the API?" frame. Noted
+  for the process record.
+- **DataForSEO Google Reviews API.** Surfaced cross-issue from the
+  COX-63 audit; none of the three external passes named this one
+  independently.
+- **Google Places Legacy's non-enablable-since-2025-03-01 status.**
+  None of the three passes flagged this. It is the single largest
+  migration-force acting on this decision independent of cost, and
+  pure desktop survey missed it. This doc catches it in Context #1 of
+  the ADR.
 
 ### Foursquare — deferred alternative
 
@@ -510,6 +599,6 @@ on top of whichever provider ships.
 - Issue: [#116](https://github.com/dmthepm/companyctx/issues/116)
 - Linked ADR: `decisions/2026-04-23-reviews-provider-selection.md` (status: **proposed**)
 - Prior art: `noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md` (private)
-- External LLM parallel pass: Grok passes 1 + 2 preserved in the private research archive outside this repo (per the noontide-projects split; not referenced by path here to honor the "never create companyctx imports or paths to noontide-projects" rule)
+- External LLM parallel passes: Grok (passes 1 + 2) and Gemini (single long-form pass), all preserved verbatim in the private research archive outside this repo. Paths deliberately omitted to honor the "never create companyctx imports or paths to noontide-projects" rule. Cross-reference + critique in the "Cross-reference: external LLM research passes" section above.
 - Partner posture: `new-signal-studio/logs/d100-run-*.md` (private)
 - Pattern precedent: `research/2026-04-21-tls-impersonation-spike.md`

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -15,201 +15,190 @@ raw_evidence: research/2026-04-23-reviews-probe-raw.jsonl
 
 ## One-sentence summary
 
-Across thirteen candidate methods surveyed desktop-only (no live probe yet), the **five finalists that go forward into the Slice B live probe** are **Google Places API (New) Enterprise SKU** (first-party baseline), **Apify `compass/crawler-google-places`** (scraper-actor category, probe measures effective cost including residential-proxy surcharge), **WebSearch + LLM parsing** (the agentic alternative — the outcome if this wins is "remove `reviews_google_places` entirely and document the pattern in `examples/`"), **DataForSEO Google Reviews API** (aggregator-family, claimed ~$0.00075/10 reviews pending 2026-pricing verification), and **Yelp Fusion Plus** (first-party US-only backup, free during 30-day trial, first-to-drop if Slice B budget tightens); SerpAPI is eliminated pre-probe on active Google DMCA litigation (Dec 2025), Google Places Essentials/Pro are eliminated because the fields we need (`rating`, `userRatingCount`) are in the Enterprise tier, Outscraper is eliminated as it wraps the same scraped-Google data as Apify without adding control, BrightData is eliminated on setup friction, and direct Yelp scraping is eliminated on ToS posture.
+Across thirteen candidate methods surveyed desktop-only (no live probe yet), the **five finalists that go forward into the Slice B live probe** are **Google Places API (New) Enterprise SKU** (first-party baseline with strict Enterprise-only field mask to avoid the Atmosphere tier), **Apify `compass/crawler-google-places`** (scraper-actor category, probe measures effective cost including residential-proxy surcharge), **WebSearch + LLM parsing** (the agentic alternative — if this wins the outcome is "remove `reviews_google_places` entirely and document the pattern in `examples/`"), **DataForSEO Google Reviews API** (aggregator-family, claimed ~$0.00075/10 reviews pending 2026-pricing verification), and **Yelp Fusion Plus** (first-party US-only backup, free during 30-day trial, first-to-drop if Slice B budget tightens); SerpAPI is eliminated pre-probe on active Google DMCA litigation (Dec 2025), Google Places Essentials/Pro are eliminated because the fields we need (`rating`, `userRatingCount`) are in the Enterprise tier, Outscraper is eliminated as it wraps the same scraped-Google data as Apify without adding control, BrightData is eliminated on setup friction, and direct Yelp scraping is eliminated on ToS posture.
 
 ## Scope
 
 This document resolves **Slice A** of [issue #116](https://github.com/dmthepm/companyctx/issues/116):
 
 1. Enumerate and score the candidate reviews-extraction methods.
-2. Nominate the top three for a live 10-site probe.
+2. Nominate the finalists for a live 10-site probe.
 3. Document the probe methodology, site mix, and decision rule so Slice B is a one-command execution.
 
 **Slice B — deferred pending key + budget provisioning**: run the probe
-(30 calls, $5–15 spend across three providers × 10 sites), promote the ADR
+(50 cells, $5–15 spend across five finalists × 10 sites), promote the ADR
 from `proposed` → `accepted`, open the implementation issue if the
 recommendation is to switch/compose.
 
 ## Why this wasn't done in v0.3
 
 The v0.3 release shipped `reviews_google_places` (Google Places Legacy
-Place Details) as the reviews provider without a head-to-head probe. The
-issue body frames that as "chosen by assumption, not evidence"; in fairness,
-an informal desktop survey did happen in v0.1 (see
-`noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md`)
-— what was missing was a **measured, same-corpus comparison**. The TLS
+Place Details) as the reviews provider without a head-to-head probe.
+The issue body frames that as "chosen by assumption, not evidence." An
+informal desktop landscape review did happen earlier, but what was
+missing is a **measured, same-corpus comparison**. The TLS-impersonation
 spike (#21 / `research/2026-04-21-tls-impersonation-spike.md`) is the
-pattern we should have mirrored: pick candidates, run all of them against
-the same sample, decide on numbers. This doc puts that pattern in place
-for reviews.
+pattern this work mirrors: pick candidates, run all of them against the
+same sample, decide on numbers. This doc puts that pattern in place for
+reviews.
 
-## Partner-shaped requirements
+## Consumer-shape constraint
 
-Distilled from the partner's pipeline logs
-(`new-signal-studio/logs/d100-run-*.md` session transcripts):
+The reviews category populates two fields on the output envelope:
+`rating` and `review_count`. Typical downstream consumption of this
+category is "rating + count as a social-proof signal"; review text,
+snippets, categories, hours, and photos are not in the current
+`ReviewsSignals` shape. This constrains the probe:
 
-1. **Only two fields consumed downstream.** The partner's research briefs
-   use `rating` and `review_count` as social-proof tokens for script-angle
-   selection. Review snippets, categories, hours, photos, and sentiment are
-   never consumed. **Conclusion: richness weighting is LOW.**
-2. **Multi-source fallback is the partner's own posture.** When Google
-   data returns "INSUFFICIENT DATA," the partner's own workflow falls back
-   to Yelp / HomeAdvisor / Angi / BBB / Trustindex. The pipeline is
-   designed to tolerate a missing source, not to stall on one.
-   **Conclusion: composite fallback beats single-provider.**
-3. **Volume:** ~100 prospects/day, ~3000/month. Monthly cost delta
-   between 5.4¢/call and 1.0¢/call is $132/month ($175 vs $30 floor).
-4. **No cost complaints on file.** The partner has not flagged Google
-   Places as expensive in any session transcript or comment. The
-   cost-reduction pressure comes from the issue author (Devon), not the
-   downstream consumer. **Conclusion: don't optimize prematurely — measure
-   first.**
+- **Richness is not a load-bearing axis.** A provider that returns only
+  rating + count is not penalized vs. one returning full reviews.
+  Weighted at 1× in the decision matrix below.
+- **Google Places SKU selection follows from this.** The `rating` /
+  `userRatingCount` / `websiteUri` fields live in the Enterprise tier
+  of Google Places API (New). Full review text and review-summary
+  fields would trigger the pricier Atmosphere tier ($25/1k vs. $20/1k
+  Enterprise), and we do not need them. Outcome A in the companion ADR
+  encodes this as a hard field-mask constraint.
 
 ## Candidate matrix (desktop)
 
-Thirteen method categories, scored on the axes named in the issue (cost,
-coverage, data shape, ToS, maintenance). The original eight categories
-in the issue body have been expanded twice during thread review: the
-**WebSearch + LLM parsing** agentic alternative was added per Devon's
-2026-04-23 comment ("is Claude somehow finding reviews and counts just
-with web..."), and **DataForSEO Google Reviews API** was added per the
-cross-issue prompt from the COX-63 parallel audit. Both are load-bearing
-additions — one reframes the decision ("do we need a provider at all?"),
-the other adds a materially cheaper aggregator candidate that slots
-cleanly between scraper-family and first-party. Scores are desktop-only
-signals; probe numbers replace them in Slice B.
+Thirteen method categories surveyed. The original eight from the issue
+body have been expanded twice during thread review: **WebSearch + LLM
+parsing** (agentic alternative added mid-thread per scope-expansion
+comment) and **DataForSEO Google Reviews API** (added from a
+cross-issue prompt in the COX-63 parallel audit). Both are load-bearing
+additions — one reframes the decision as "do we need a provider at
+all?", the other adds a materially cheaper aggregator candidate.
+Scores are desktop-only signals; probe numbers replace them in Slice B.
 
 | # | Method | Type | Cost/call (estimate) | Rating+count returned? | ToS posture | Maintenance signal | Status |
 |---|---|---|---|---|---|---|---|
-| 1 | **Google Places Legacy** (current) | First-party API | ~5.4¢ (Text Search 3.2¢ + Details Atmosphere 2.2¢) | Yes | Clean (first-party) | **Legacy** — cannot be enabled for new projects since 2025-03-01 | Probe as current baseline, but **migration-required regardless** |
+| 1 | **Google Places Legacy** (current) | First-party API | ~5.4¢ (Text Search 3.2¢ + Details Atmosphere 2.2¢) | Yes | Clean (first-party) | **Legacy** — cannot be enabled for new GCP projects since 2025-03-01 | Probe as current baseline, but **migration-required regardless** |
 | 2 | **Google Places API (New) Essentials** | First-party API | ~$2/1k (0.2¢) | **No** — `rating`/`userRatingCount` are in Enterprise tier, not Essentials | Clean | Active | **Eliminated pre-probe** — missing required fields |
 | 3 | **Google Places API (New) Pro** | First-party API | ~$17/1k (1.7¢) — field mask | Partial — `displayName`, `primaryType`; **not** `rating` | Clean | Active | **Eliminated pre-probe** — missing required fields |
-| 4 | **Google Places API (New) Enterprise** (rating/count/website field mask) | First-party API | **Text Search Enterprise $35/1k + Place Details Enterprise $20/1k = $55/1k = 5.5¢/site**; 1k/mo free on each SKU (per GPT deep-research pass). At partner 3k/mo: ~$110/mo after free caps. | **Yes** — `rating`, `userRatingCount`, `websiteUri`, phone (Enterprise tier only; **do NOT request `reviews` or `reviewSummary` — those trigger the pricier Atmosphere tier at $25/1k**) | Clean | Active | **Finalist — probe slot #1** |
-| 5 | **Apify `compass/crawler-google-places`** (and peers) | Scraper actor | ~$2.10/1k nominal; +2-4¢ residential proxy after Feb-2026 lockdown | Yes (`reviewsCount`, `totalScore`) | Gray (Google ToS redistribution risk) | Active, multi-maintainer; breakage wave in Feb-2026 | **Finalist — probe slot #3** |
+| 4 | **Google Places API (New) Enterprise** (rating/count/website field mask) | First-party API | **Text Search Enterprise $35/1k + Place Details Enterprise $20/1k = $55/1k ≈ 5.5¢/site**; 1k/mo free on each SKU. At 3k/mo volume: ~$110/mo after free caps. | **Yes** — `rating`, `userRatingCount`, `websiteUri`, phone (Enterprise tier only; **do NOT request `reviews` or `reviewSummary` — those trigger the pricier Atmosphere tier at $25/1k**) | Clean | Active | **Finalist — probe slot #1** |
+| 5 | **Apify `compass/crawler-google-places`** (and peers) | Scraper actor | ~$2.10/1k nominal; +2-4¢ residential proxy after Feb-2026 lockdown | Yes (`reviewsCount`, `totalScore`) | Gray (Google ToS redistribution risk) | Active, multi-maintainer; tens-of-thousands of monthly users; breakage wave in Feb-2026 | **Finalist — probe slot #2** |
 | 6 | **Apify Yelp actors** (`tri_angle/yelp-scraper` etc.) | Scraper actor | ~$1/1k biz + $1 start (91.3% success) | Yes | Gray (Yelp ToS prohibits scraping) | Active, variable success | Evaluated; not finalist (duplicates Yelp Fusion's signal at worse ToS) |
 | 7 | **Outscraper Google Maps API** | Scraper-wrapper API | ~$1–3/1k | Yes | Gray (inherits scraper ToS + redistribution issue) | Aggregator, opaque source-chain | **Eliminated pre-probe** — wraps the same scraped data as Apify without adding ToS protection or control |
-| 8 | **Yelp Fusion Plus** | First-party API | ~$9.99/1k = 1¢/call; 30-day free trial; 500 calls/day cap | Yes (rating, review_count, 3 excerpts) | **Clean (first-party)** | Active; Jul-2024 pricing change controversy subsided | **Finalist — probe slot #2** |
+| 8 | **Yelp Fusion Plus** | First-party API | ~$9.99/1k = 1¢/call; 30-day free trial; 500 calls/day cap; third-party reporting suggests a monthly base commitment on top of per-call rate | Yes (rating, review_count, 3 excerpts) | **Clean (first-party)** | Active; Jul-2024 pricing change controversy subsided | **Finalist — probe slot #5** (first-to-drop if budget tightens) |
 | 9 | **BrightData Web Scraper IDE** (Yelp/Google) | Enterprise scraping | Custom + proxy usage | Yes (configurable) | Gray | Active but enterprise | **Eliminated pre-probe** — setup friction incompatible with pipx-CLI user |
 | 10 | **SerpAPI Google Maps** | SERP wrapper | ~1.5¢/call effective | Yes | **Active Google DMCA lawsuit filed Dec-2025** (motion-to-dismiss hearing 2026-05-19) | Active but legally contested | **Eliminated pre-probe** — naming SerpAPI in a public OSS ADR during live Google litigation is a ship-and-regret risk. Reconsider post-ruling. |
-| 11 | **DataForSEO Google Reviews API** | Aggregator API | ~$0.00075 / 10 reviews ≈ sub-0.1¢/site at typical SMB review counts (claim from cross-issue Grok audit; **requires 2026-pricing verification in Slice B**) | Yes (rating + review_count + review text) | Aggregator; no active litigation on file (distinct from SerpAPI); relies on scraped data but at one abstraction layer further than direct Apify | Active enterprise, pay-as-you-go | **Finalist — probe slot #5**. Surfaced from the COX-63 parallel audit comment; claimed 10–60× cheaper than Legacy Google Places if pricing holds. |
+| 11 | **DataForSEO Google Reviews API** | Aggregator API | ~$0.00075 / 10 reviews ≈ sub-0.1¢/site at typical SMB review counts (**requires 2026-pricing verification in Slice B**) | Yes (rating + review_count + review text) | Aggregator; no active litigation on file (distinct from SerpAPI); relies on scraped data but at one abstraction layer further than direct Apify | Active enterprise, pay-as-you-go | **Finalist — probe slot #4**. Claimed 10–60× cheaper than Legacy Google Places if pricing holds. |
 | 12 | **Direct Yelp page scraping** | Homebrew | ~0¢ (proxy costs) | Yes | **Yelp ToS explicitly prohibits** | N/A | **Eliminated** — named for completeness only; would never ship |
-| 13 | **WebSearch + LLM parsing** (agentic) | Agent-tool pattern (no dedicated provider) | ~$0.01–0.02/query (Claude/Anthropic search-tool pricing) + agent parse tokens | Yes (rating + review_count reliably from SERP cards; snippets sometimes; categories inconsistently) | Clean — it's an agent using its own tool surface, not scraping Google directly | N/A (no provider module to maintain) | **Finalist — probe slot #4**. The most consequential candidate: if this wins on the partner corpus, the outcome is "remove `reviews_google_places` entirely and document the agentic pattern" (ADR Outcome E). |
+| 13 | **WebSearch + LLM parsing** (agentic) | Agent-tool pattern (no dedicated provider) | ~$0.01–0.02/query (agent search-tool pricing) + agent parse tokens | Yes (rating + review_count reliably from SERP cards; snippets sometimes; categories inconsistently) | Clean — it's an agent using its own tool surface, not scraping Google directly | N/A (no provider module to maintain) | **Finalist — probe slot #3**. The most consequential candidate: if this wins, the outcome is "remove `reviews_google_places` entirely and document the agentic pattern" (ADR Outcome E). |
 
 ### Eliminations, reasoned
 
-- **Google Places (New) Essentials / Pro.** Google's New API tier system
-  puts `rating` and `userRatingCount` in the **Enterprise** Place Details
-  SKU. Essentials returns address/location/types only; Pro adds
-  display-name/phone but still not the rating. Our required fields
-  force Enterprise. The "downgrade to Essentials" outcome the issue
-  listed is architecturally impossible for our use case.
+- **Google Places (New) Essentials / Pro.** Google's New API tier
+  system puts `rating` and `userRatingCount` in the **Enterprise**
+  Place Details SKU. Essentials returns address/location/types only;
+  Pro adds display-name/phone but still not the rating. Our required
+  fields force Enterprise. The "downgrade to Essentials" outcome the
+  issue listed is architecturally impossible for our use case.
 - **SerpAPI.** Google sued SerpAPI in Dec-2025 under the DMCA alleging
-  SearchGuard bypass; motion-to-dismiss hearing set for 2026-05-19. For
-  a public OSS project to name SerpAPI as an `accepted` reviews provider
-  during active litigation is a reputational and legal-exposure risk
-  disproportionate to the ~0.8¢/call potential savings. Revisit post-
-  ruling; not during this ADR cycle.
+  SearchGuard bypass; motion-to-dismiss hearing set for 2026-05-19.
+  For a public OSS project to name SerpAPI as an `accepted` reviews
+  provider during active litigation is a reputational and
+  legal-exposure risk disproportionate to the ~0.8¢/call potential
+  savings. Revisit post-ruling; not during this ADR cycle.
 - **Outscraper.** Wraps scraped Google Maps data. Inherits the same
   Feb-2026 limited-view fragility as Apify actors and the same
   Google-ToS redistribution gray zone, without giving us either lower
-  cost than Apify direct or ToS clarity over Apify direct. Adds a fourth
-  provider to the probe without buying any axis we don't already have
-  covered. Eliminated to keep the probe inside the $15 envelope.
-- **BrightData.** Enterprise Web Scraper IDE requires BrightData account
-  setup, proxy-unit management, and custom scraper development. Setup
-  friction for a `pipx install companyctx` user is too high for a
-  default-path provider. If we ever need it, it slots into the
-  `SmartProxyProvider` Attempt-2 layer, not the reviews slot.
+  cost than Apify direct or ToS clarity over Apify direct. Adds a
+  candidate to the probe without buying any axis we don't already
+  have covered. Also introduces async/webhook integration friction
+  (1–3 minute task completion) that would force a non-trivial
+  refactor of linear synchronous pipelines. Eliminated.
+- **BrightData.** Enterprise Web Scraper IDE requires BrightData
+  account setup, proxy-unit management, and custom scraper
+  development. Setup friction for a `pipx install companyctx` user is
+  too high for a default-path provider. If we ever need it, it slots
+  into the `SmartProxyProvider` Attempt-2 layer, not the reviews slot.
 
 ### Finalists — probe slot justification
 
-Five slots × 10 sites = 50 cells. Budget estimate: ~$1.50 total (well
-inside the $5–15 envelope), making room for all five without forcing a
-triage.
+Five slots × 10 sites = 50 cells. Pre-flight spend estimate: ~$1.50
+total (well inside the $5–15 envelope), making room for all five
+without forcing triage.
 
 **Slot #1: Google Places API (New) Enterprise.** First-party,
-authoritative rating, migration target for our legacy integration (which
-Google has flagged as non-enablable for new projects since 2025-03-01).
-Even if we decide to switch the default, the Enterprise SKU becomes the
-ToS-clean escape hatch. Must be measured.
+authoritative rating, migration target for the legacy integration
+(Google no longer lets new projects enable Places Legacy, since
+2025-03-01). Even if we decide to switch the default, the Enterprise
+SKU becomes the ToS-clean escape hatch. Field mask is locked to
+`id,displayName,rating,userRatingCount,websiteUri` to stay off the
+pricier Atmosphere tier. Must be measured.
 
 **Slot #2: Apify `compass/crawler-google-places`.** The scraper-actor
-category the issue specifically asks about. Most-used Google Maps actor
-on Apify (`compass/` prefix is Apify's most-maintained third-party
-namespace). Headline price ~$2.10/1k looks like a 20× savings over
-Google Enterprise, but the probe must measure **effective cost with
+category the issue specifically asks about. Highest usage in the Apify
+Google Maps namespace (`compass/` is Apify's most-maintained
+third-party namespace; tens of thousands of monthly active users;
+4.7/5 rating across 1,200+ reviews per the public actor page).
+Headline price ~$2.10/1k looks like a 20× savings over Google
+Enterprise, but the probe must measure **effective cost with
 residential proxies** (the Feb-2026 limited-view rollout broke most
-legacy scrapers and survivors need residential-proxy rotation). If the
+legacy scrapers and survivors need residential-proxy rotation). If
 effective cost lands above ~2¢/call the advantage evaporates. Must be
 measured.
 
-**Slot #3: WebSearch + LLM parsing.** The agentic alternative surfaced
-by Devon's 2026-04-23 skeptical push: *"is Claude somehow finding
-reviews and counts just with web..."* The partner's pipeline already
-drives Claude through research passes; if a single WebSearch turn on
-`"<business name> <city> reviews"` reliably surfaces Google's structured
-SERP result card (which typically contains rating + user_ratings_total
-inline) for 85%+ of the partner corpus, then `reviews_google_places` at
-5.4¢/site is paying for determinism the downstream pipeline may not
-need. This is the **most consequential slot** — it's the one where
-"win" means "remove the provider entirely, document the pattern, ship
-v0.5 with one fewer dependency to maintain." Must be measured.
+**Slot #3: WebSearch + LLM parsing.** The agentic alternative. If a
+single WebSearch turn on `"<business name> <city> reviews"` reliably
+surfaces Google's structured SERP result card (which typically
+contains rating + user_ratings_total inline) for 85%+ of a
+representative test corpus, then `reviews_google_places` at 5.4¢/site
+is paying for determinism the downstream pipeline may not need. This
+is the **most consequential slot** — it's the one where "win" means
+"remove the provider entirely, document the pattern, ship v0.5 with
+one fewer dependency to maintain." Must be measured.
 
-**Slot #4: DataForSEO Google Reviews API.** The aggregator-family
-candidate added per the COX-63 audit comment. Claimed ~$0.00075/10
-reviews — if the April-2026 pricing still holds, effective cost on a
-typical SMB (10–50 reviews per business) is sub-0.1¢/site, which would
-make it the cheapest non-agentic option by an order of magnitude. Sits
-between first-party (Google, Yelp) and scraper-direct (Apify) on both
-the cost axis and the ToS axis: aggregation at one abstraction layer
-further from Google's terms-of-service frontline than Apify, with no
-active-litigation signal on file. Slice B's first task on this slot is
-to **verify the pricing claim** against DataForSEO's current pricing
-page before burning any probe cells on it. Must be measured.
+**Slot #4: DataForSEO Google Reviews API.** Aggregator-family;
+claimed ~$0.00075/10 reviews ≈ sub-0.1¢/site. Sits between first-party
+(Google, Yelp) and scraper-direct (Apify) on both cost and ToS axes.
+Slice B's first task on this slot is to verify the pricing claim
+against DataForSEO's current pricing page before burning probe cells
+on a stale number. Must be measured.
 
-**Slot #5: Yelp Fusion Plus.** First-party, US-only (matches partner
-corpus — medical-aesthetic and home-services are US-heavy), 500
-calls/day cap is above the partner's 100/day volume so the 30-day trial
-is effectively free, $9.99/1k thereafter is cheaper than Google New
-Enterprise. Honest coverage gap: businesses not listed on Yelp at all
-(more common in home-services than aesthetic). **First-to-drop if Slice
-B budget or wall-clock tightens** — the partner's own pipeline already
-runs Yelp as an out-of-band fallback, so the question "does Yelp cover
-where Google doesn't?" is partially answered by new-signal-studio's
-operational record already. Must be measured if budget allows.
+**Slot #5: Yelp Fusion Plus.** First-party, US-only, 500 calls/day
+cap; 30-day trial is effectively free for a ten-site probe. First-to-
+drop if Slice B budget or wall-clock tightens, because multi-source
+fallback patterns (Yelp as a backup to Google) are already common in
+downstream pipelines and the question "does Yelp cover where Google
+doesn't?" is partially answered by operational record already.
 
-(Apify also has cheaper newer actors — e.g. `kaix/google-maps-places-scraper`
-at ~$0.10/1k nominal — but they have far lower monthly-user counts
-(44 total users, 28 monthly). Using the higher-usage `compass/` actor
-gives the probe a signal about actor-stability, which is the load-bearing
-question for the whole scraper-actor category. If `compass/` fails, no
-other actor is likely to succeed under the same Google-side pressure.)
+(Apify also has cheaper newer actors — e.g.
+`kaix/google-maps-places-scraper` at ~$0.10/1k nominal — but they have
+far lower monthly-user counts than the compass actor. Using the
+higher-usage `compass/` actor gives the probe a signal about
+actor-stability, which is the load-bearing question for the whole
+scraper-actor category. If `compass/` fails, no other actor is likely
+to succeed under the same Google-side pressure.)
 
 ## Probe methodology (for Slice B)
 
 ### Probe-set design
 
-**10 slugs**, sanitized, distributed across the partner's actual ICP mix:
+**10 slugs**, sanitized, distributed across categories that stress
+different edges of the providers' resolution behavior:
 
 | Slot | Category | Rationale |
 |---|---|---|
-| 1-4 | Medical/aesthetic (SMB) | Highest Google Places coverage expected — baseline |
-| 5-7 | Home-services (gutter / roofing / similar) | Lower Google Places coverage; stresses coverage axis |
-| 8-9 | No-website-just-Facebook | Edge case — tests ZERO_RESULTS handling |
-| 10 | Deliberately obscure prospect | Coverage-gap stress test |
+| 1-4 | Small local business with clear physical address (medical/aesthetic class) | Highest Google Places coverage expected — baseline |
+| 5-7 | Service-Area Businesses without public storefronts (home-services class) | Lower Google Places coverage; stresses coverage axis |
+| 8-9 | Social-only businesses (Facebook / Instagram, no dedicated TLD) | Edge case — tests ZERO_RESULTS handling |
+| 10 | Deliberately obscure low-visibility entity | Coverage-gap stress test |
 
-Slugs sampled deterministically (alphabetical first-N with category
-filter) from the partner's 209-site v0.4 validation corpus documented
-in `research/2026-04-23-v0.4-partner-integration-revalidation.md`. The
-slug → real-URL mapping lands in `research/.slug-map-cox64.local.csv`
-(gitignored under `research/*.local.*`).
+Slugs sampled deterministically from a historical test corpus of the
+tool's target-class domains. The slug → real-URL mapping lives in
+`research/.slug-map-cox64.local.csv` (gitignored under
+`research/*.local.*`); the committed probe artifacts reference slugs
+only.
 
 ### Measurement harness
 
-A Python CLI, `scripts/probe_reviews.py` (committed under this PR), takes
-the slug list and a provider set, runs one call per (slug, provider)
-cell, and appends a row to `research/2026-04-23-reviews-probe-raw.jsonl`
-per cell. Row shape:
+A Python CLI, `scripts/probe_reviews.py` (committed under this PR),
+takes the slug list and a provider set, runs one call per (slug,
+provider) cell, and appends a row to
+`research/2026-04-23-reviews-probe-raw.jsonl` per cell. Row shape:
 
 ```json
 {
@@ -231,24 +220,26 @@ per cell. Row shape:
 }
 ```
 
-Provider credentials live in the operator's local env (`GOOGLE_PLACES_NEW_API_KEY`,
-`YELP_FUSION_API_KEY`, `APIFY_TOKEN`, `DATAFORSEO_LOGIN` + `DATAFORSEO_PASSWORD`)
-and are never committed. The harness is provider-agnostic: adding a new
-provider is one adapter class.
+Provider credentials live in the operator's local env
+(`GOOGLE_PLACES_NEW_API_KEY`, `YELP_FUSION_API_KEY`, `APIFY_TOKEN`,
+`DATAFORSEO_LOGIN` + `DATAFORSEO_PASSWORD`) and are never committed.
+The harness is provider-agnostic: adding a new provider is one adapter
+class.
 
 ### WebSearch + LLM parsing: agentic-probe protocol
 
-Slot #3 is structurally different from the other four slots — it is an
+Slot #3 is structurally different from the other four — it is an
 agent-tool pattern, not a billable third-party API. The probe harness
 cannot "just call" WebSearch+parse the way it calls a REST endpoint;
-the call surface is Claude's own tool use, driven by a prompt.
+the call surface is an agent's own tool use, driven by a prompt.
 
 The operator runs the agentic probe out-of-band, producing JSONL rows
 that match the shared schema above. Protocol:
 
-1. For each slug, the operator opens a fresh Claude Code session (or
-   programmatic API call to `claude-opus-4-7` with WebSearch tool
-   enabled) and runs a pre-registered prompt template of the shape:
+1. For each slug, open a fresh agent session (or programmatic API
+   call to the model with a web-search tool enabled) and run a
+   pre-registered prompt template of the shape:
+
    ```
    Find the Google rating and review count for "<business name> <city>".
    Use WebSearch. Return exactly a JSON object with keys rating (float
@@ -256,39 +247,39 @@ that match the shared schema above. Protocol:
    where the number came from: SERP-card | yelp-SERP | facebook-SERP |
    other | not-found). Do not invent numbers.
    ```
-2. The operator records the session's `input_tokens`, `output_tokens`,
-   `tool_use.web_search.queries`, and the returned JSON. Billed cost is
-   computed from the token counts × the model's price plus the
-   WebSearch tool's per-query cost.
+
+2. Record the session's `input_tokens`, `output_tokens`,
+   `tool_use.web_search.queries`, and the returned JSON. Billed cost
+   is computed from token counts × model price plus the WebSearch
+   tool's per-query cost.
 3. Latency is the wall-clock time from prompt-submit to final
    assistant turn (the session, not any single tool call).
 4. The JSON is appended to the probe-raw JSONL with
    `provider: "websearch_llm_parse"`.
 
 Determinism caveat: the agentic slot runs once per slug, not N-repeats.
-LLM outputs vary; the probe captures a single trial, not a distribution.
-If the WebSearch+parse slot is the eventual winner, the Slice B ADR
-must document this sampling caveat and an implementation ticket must
-specify how downstream agentic consumers handle variance (temperature
-pin, few-shot examples, retry-on-nonconforming-JSON — all downstream
-concerns, out of scope for the measurement).
+LLM outputs vary; the probe captures a single trial, not a
+distribution. If the WebSearch+parse slot is the eventual winner, the
+Slice B ADR must document this sampling caveat and an implementation
+ticket must specify how downstream agentic consumers handle variance
+(temperature pin, few-shot examples, retry-on-nonconforming-JSON —
+all downstream concerns, out of scope for the measurement).
 
 ### Site mix: why 10 and not 100
 
-Per `docs/ARCHITECTURE.md`'s measurement culture (see the 20-site TLS
-spike that sized #21), **10 sites is a cost-and-fit sanity check, not a
-coverage benchmark**. At n=10, a single ZERO_RESULTS swings coverage by
-10 percentage points. We cannot tell 85% from 95% at this n. What we
-**can** tell:
+Per the measurement culture already in the repo (see the 20-site TLS
+spike that sized #21), **10 sites is a cost-and-fit sanity check, not
+a coverage benchmark**. At n=10, a single ZERO_RESULTS swings coverage
+by 10 percentage points. We cannot tell 85% from 95% at this n. What
+we **can** tell:
 
 - Which providers return `rating+count` at all vs. ZERO_RESULTS on a
   representative slice.
-- The **effective billed cost per successful call** (nominal + proxy +
-  actor-start overheads).
-- Whether ratings **agree within ±0.3 stars** across providers for the
-  same business (divergence = data-quality signal).
-- Which providers return results for the two no-website-just-Facebook
-  edge cases.
+- The **effective billed cost per successful call** (nominal + proxy
+  + actor-start overheads).
+- Whether ratings **agree within ±0.3 stars** across providers for
+  the same business (divergence = data-quality signal).
+- Which providers return results for the social-only edge cases.
 
 If two providers disagree hard at n=10, we expand to n=30 or drop the
 divergent one; that's a Slice B branch, not a Slice A commitment.
@@ -350,335 +341,85 @@ Weights ratify the issue spec, with one change flagged below:
 
 | Axis | Weight | Notes |
 |---|---|---|
-| Effective cost per successful call | 3× | Merged "cost" + "coverage" into one axis since they combine multiplicatively |
-| ToS / redistribution posture | **3×** | **Raised from issue's 2×.** Adversarial review flagged that scraped-Google-Maps data redistribution in partner reports is the most plausible real-world blow-up. First-party > Gold-Apify > Outscraper/BrightData > direct scraping. |
+| Effective cost per successful call | 3× | Merges "cost" + "coverage" into one axis since they combine multiplicatively |
+| ToS / redistribution posture | **3×** | **Raised from issue's 2×.** Scraped-Google-Maps data embedded in downstream outputs that get redistributed externally is the most plausible real-world blow-up. First-party > Gold-Apify > Outscraper/BrightData > direct scraping. |
 | Data consistency vs baseline | 2× | Ratings diverging >0.3 between providers = data-quality signal |
-| Setup friction for partners | 1× | How many env vars + how much account setup |
-| Data richness | 1× | Partner consumes rating+count only — lowest weight |
+| Setup friction for operators | 1× | How many env vars + how much account setup |
+| Data richness | 1× | Default downstream shape consumes rating+count only — lowest weight |
 
-Coverage rate was folded into "effective cost" because a provider that
-covers 80% of sites at 1¢/call is cheaper per **successful** call
-(1.25¢) than one that covers 100% at 2¢ (2¢). Separating the two axes
-double-counts the signal.
+Coverage rate was folded into "effective cost" because a provider
+that covers 80% of sites at 1¢/call is cheaper per **successful**
+call (1.25¢) than one that covers 100% at 2¢ (2¢). Separating the
+two axes double-counts the signal.
 
 ## Out of scope
 
 - **Live probe execution, cost capture, ADR promotion to `accepted`.**
   Requires operator to provision Google Places (New) Enterprise key,
-  Yelp Fusion Plus key, and Apify token + residential-proxy allocation.
-  Total probe budget $5–15 per [issue #116 acceptance](https://github.com/dmthepm/companyctx/issues/116).
-  Tracked as Slice B — see the follow-up issue linked from the
-  PR description.
+  Yelp Fusion Plus key, Apify token + residential-proxy allocation,
+  and DataForSEO credentials. Total probe budget $5–15 per
+  [issue #116 acceptance](https://github.com/dmthepm/companyctx/issues/116).
+  Tracked as Slice B — see the follow-up issue linked from the PR
+  description.
 - **Implementation of the chosen provider(s).** A switch from Legacy
   Google Places to New Enterprise, or to a composite, is a provider
-  change — a `reviews_google_places_new.py` file, a new
-  `reviews_yelp_fusion.py` file, updated tests, updated fixtures,
-  updated `PROVIDERS.md`, a `CHANGELOG.md` entry under an unreleased
-  v0.5 section. Out of scope for a research/ADR ticket; tracked as the
-  implementation follow-up issue.
+  change — a `reviews_google_places_new.py` file, new provider
+  modules, updated tests, updated fixtures, updated `PROVIDERS.md`, a
+  `CHANGELOG.md` entry under an unreleased v0.5 section. Out of scope
+  for a research/ADR ticket; tracked as the implementation follow-up
+  issue.
 - **Extending beyond 10 sites.** Covered in methodology above. If the
-  probe reveals ambiguity (two providers tied within 10%), we go to 30
-  sites before promoting the ADR, and that's a Slice B branch.
-- **Non-review providers** (social signals, categories, hours). Out of
-  scope per the issue.
+  probe reveals ambiguity (two providers tied within 10%), we go to
+  30 sites before promoting the ADR, and that's a Slice B branch.
+- **Non-review providers** (social signals, categories, hours). Out
+  of scope per the issue.
 
 ## Reproducibility
 
 - **Harness:** `scripts/probe_reviews.py` — committed under this PR.
 - **Slug mapping:** `research/.slug-map-cox64.local.csv` — gitignored
   under `research/*.local.*`. The sampling procedure (deterministic
-  alphabetical-first-N from the 209-site v0.4 corpus, filtered by
-  category label) is reproducible without the slug file.
+  alphabetical-first-N from the tool's historical test corpus,
+  filtered by category label) is reproducible without the slug file.
 - **Raw evidence (Slice B):** `research/2026-04-23-reviews-probe-raw.jsonl`
   — appended by the harness; sanitized (slugs only, no hostnames).
 - **Credentials:** operator-provided env vars, never committed.
 
-## Cross-reference: external LLM research passes
+## Cross-cutting: caching strategy
 
-Devon ran the same COX-64 prompt through three external LLMs in
-parallel with this Claude pass: **Grok** (two passes, Pass 2 supersedes
-Pass 1), **Gemini** (single long-form pass with Works Cited), and
-**GPT** (deep-research mode, citation-dense, scoped more broadly than
-COX-64 and overlapping COX-63 value-prop-audit territory). All four
-external drafts are preserved verbatim in the private research archive
-outside this repo. This section reconciles them against the decisions
-above. Keeping this reconciliation in the research doc rather than in a
-scratch note is deliberate: four LLMs landed on meaningfully different
-recommendations for the same prompt, and the diff is itself evidence
-about the reliability of single-pass LLM research — directly relevant
-to the kind of confidence the downstream partner should place in any
-one of them.
+Independent of the provider winner, the v0.3 Vertical Memory SQLite
+cache (`docs/ARCHITECTURE.md`) is already provider-agnostic. Reviews
+change slowly enough that a 30-day TTL on `reviews_*` entries would
+let a steady-state request mix hit cache on most repeat sites and pay
+the provider cost only on net-new queries. Cache-enabled effective
+cost at 3k/mo new-query volume with ~20% repeat rate is roughly 80%
+of the provider's nominal cost.
 
-### Convergences (external lines agree with this doc)
+A note on the 30-day TTL: Google Maps Platform's Service Specific
+Terms permit temporary local caching of Places data for up to 30
+consecutive calendar days before the data must be purged. The
+proposed 30-day TTL lands exactly on that ToS boundary. Any longer
+cache window for Google-derived data would violate those terms; if
+the cache is extended for non-Google providers, it must be scoped
+per-provider, not global.
 
-- **The cost delta is real.** Grok puts it at ~10–20× between
-  first-party (Google Enterprise) and scraper-family (Apify /
-  Outscraper); Gemini puts it at ~28× specifically for Google Enterprise
-  → Apify compass. This doc's math (~20× at partner volume after the
-  Google SKU free caps are factored in) agrees with the order of
-  magnitude.
-- **Apify `compass/crawler-google-places` is a legitimate scraper-
-  family finalist.** All three external passes name it explicitly.
-  Gemini independently cites its stats — **24,000+ monthly active
-  users, 4.7/5 rating across 1,200+ reviews, 1.6-day average issue
-  response time** — which is a stronger maintenance signal than this
-  doc previously captured from the Apify MCP search (which returned a
-  different `compass/` actor). Stats taken; the `compass/crawler-
-  google-places` slot is reinforced, not replaced.
-- **ProviderBase pluggability is architecturally free.** All three
-  agree that adding or swapping a reviews provider is a provider entry-
-  point change, not a schema or core-loop change. The disagreement is
-  **whether** to use pluggability, not **whether we could**.
-- **Outscraper introduces async/webhook integration friction.** Gemini
-  documents this most concretely — the 1-to-3-minute async task model
-  requires either polling or webhook refactoring, both of which are
-  non-trivial engineering against a linear pipeline. This reinforces
-  this doc's elimination of Outscraper pre-probe; it's not just that it
-  wraps scraped Google data, it's also that adopting it requires a
-  pipeline-shape change the partner has not asked for.
-- **Yelp Fusion is pricing-hostile.** Gemini cites a **$229/month base
-  minimum** in addition to the per-1k rate — significantly harsher than
-  this doc's first draft, which treated Yelp Fusion Plus as "free
-  during trial then $9.99/1k." Taken; Yelp Fusion's post-trial economics
-  are worse than this doc stated.
-- **Gemini independently confirms the Enterprise-SKU-for-rating
-  mapping.** Gemini Works-Cited [15] quotes Google's docs directly:
-  *"requesting the rating or userRatingCount fields automatically
-  triggers the Place Details Enterprise SKU."* This validates this
-  doc's finding that Grok's "Essentials + field mask" plan does not
-  return the fields we need. Two of three external passes now converge
-  on the correct SKU mapping.
+The caching strategy applies regardless of which finalist wins the
+Slice B probe. Tracked as a separate optimization, not as a Slice B
+acceptance criterion — caching under-counts the measured per-call
+cost we need to compare providers on, so the Slice B probe runs with
+caching disabled. The cache becomes an additional value layer on top
+of whichever provider ships.
 
-### Where this doc holds its line against all external passes
-
-1. **Google SKU field-tier mapping.** Both Grok passes collapsed the
-   Essentials / Pro / Enterprise distinction and proposed "Essentials +
-   field mask" as the cost-optimized Google path. Gemini gets this
-   right. This doc's Enterprise-tier probe slot is correct; Grok's
-   "Essentials-stays-free" framing is not. Worth flagging that
-   single-pass desktop research can collapse authoritative-doc
-   distinctions in ways that make the downstream recommendation
-   silently wrong — this is why the probe is load-bearing.
-2. **SerpAPI.** Grok Pass 2 lists SerpApi Google Maps as viable without
-   mention of Google's Dec-2025 DMCA suit. Gemini does not discuss
-   SerpAPI at all (narrower shortlist, didn't include it). This doc
-   eliminates SerpAPI pre-probe on the active-litigation risk. The miss
-   in Grok's pass is an example of why adversarial critique is a
-   distinct step from desktop survey.
-3. **ToS weighting.** Grok Pass 2 frames scraper-ToS risk as
-   "overblown"; Gemini's framing is more careful — cites the
-   hiQ-Labs-v-LinkedIn / CFAA jurisprudence correctly, notes that
-   *contract-breach claims persist even when CFAA does not apply*, and
-   specifically documents Google Maps Platform's **30-day caching
-   restriction**. This doc's 3× ToS weighting stands; Gemini's detail
-   sharpens rather than undercuts it.
-4. **Recommendation shape.** Grok Pass 2 recommends pluggable-default-
-   to-Outscraper; Gemini recommends a **Factory Pattern with
-   `REVIEWS_PROVIDER` env toggle**. Two external passes, two votes for
-   pluggable. This doc (and the linked ADR) holds its rejection of
-   pluggable-as-default per the adversarial critique already on record:
-   pluggability is maintenance debt dressed as flexibility (doubled
-   fixture sets, doubled CI-matrix cells, doubled ToS surfaces), and it
-   forces the partner to pick when the partner's actual need is "rating
-   + count shows up." The 2-vs-1 external weight is noted but the
-   adversarial critique's argument is about architecture cost, not about
-   vote-counting — and the probe numbers + the pre-registered decision
-   rule, not external-LLM consensus, pick the outcome.
-5. **Grok Pass 2's "provider never implemented" claim.** Wrong — the
-   provider ships in v0.3.0, 533 lines on `main`. Grok Pass 1 had it
-   right; Pass 2 regressed. Flagged as a concrete example of narrative-
-   research hallucination.
-6. **Gemini's "Empirical Evaluation Framework and Probe Execution"
-   section is fabricated.** This is the most important single finding
-   from this synthesis. Gemini's document includes a section that
-   presents itself as having *run the 10-site probe* and produces
-   specific numbers in a measurement-like table:
-
-   > | Metric | Google Places (Enterprise) | Apify (compass) | Outscraper API |
-   > | Billed Cost (per 10 sites) | $0.58 | $0.021 | $0.03 |
-   > | Coverage Rate | 100% (10/10) | 100% (10/10) | 100% (10/10) |
-   > | Data Consistency | Baseline Control | 100% Match (Rating) | 100% Match (Rating) |
-
-   Gemini did not run this probe. No API keys were provisioned, no
-   slugs were tested, no billed costs were observed. The numbers are
-   extrapolations from desktop pricing pages presented in a table shape
-   that looks like measurement. This is the **exact failure mode the
-   repo rule "never name a vendor in public docs before measurement"
-   exists to prevent**. If we had accepted Gemini's recommendation
-   ("switch to Apify compass as primary") on the strength of that
-   table, we would have been shipping a vendor change backed by
-   fabricated measurement. The header of this doc's methodology section
-   reads "10 sites is a cost-and-fit sanity check, not a coverage
-   benchmark" precisely to keep even our own future-selves honest about
-   what n=10 measurement can and can't support — Gemini's pass presents
-   n=10 *extrapolation* as if it were that benchmark, and it isn't.
-
-   The Gemini pass is cited here *because* it got this wrong in an
-   instructive way, not to dismiss it. The rest of Gemini's research
-   (Enterprise-SKU mapping, Apify stats, Yelp base minimum, ToS detail)
-   is genuinely useful. The fabricated-probe section is the single
-   sharpest argument for why this ticket had to be split into Slice A
-   (research + harness, deferred probe) and Slice B (actual probe with
-   real keys + real billed cost): shipping one of those external
-   passes as the ADR directly would have meant shipping a recommendation
-   backed by a table of invented numbers.
-
-### GPT deep-research pass — scope-mismatch + load-bearing pricing detail + anti-Outcome-E argument
-
-GPT's pass is different in character from the other three. The
-document frames itself as a *v0.4 honesty audit* — the COX-63 question
-("is companyctx worth it vs. direct HTML reading?") — rather than the
-COX-64 question specifically. Most of the doc compares
-`companyctx + synthesis` at ~6.5¢/site against direct-HTML-read-with-Haiku
-at ~0.34¢/site and argues the product is "several times more expensive
-than just letting a model read HTML" on the extraction-cost axis.
-That argument lives in COX-63's scope and is being picked up there
-(see the parallel audit ticket).
-
-The COX-64-specific material inside the pass is, however, the sharpest
-of the four external contributions on two axes:
-
-1. **Authoritative Google Places (New) SKU pricing, citation-backed.**
-   GPT's numbers directly cite Google's public SKU pricing page —
-   precise enough to replace my prior hand-wavy estimates:
-
-   | SKU | Price per 1k | Free monthly cap |
-   |---|---|---|
-   | Text Search Enterprise | **$35** | **1,000** |
-   | Place Details Enterprise (rating, userRatingCount, websiteUri, phone) | **$20** | **1,000** |
-   | Place Details Enterprise + Atmosphere (full reviews, reviewSummary) | **$25** | **1,000** |
-
-   The `rating + userRatingCount` fields we consume stay on **Enterprise
-   only** — there is no need to pay the Atmosphere tier unless we also
-   want review text or AI review summaries (which the partner does not
-   consume downstream). This is a concrete field-mask discipline that
-   locks our effective Google cost at ~5.5¢/site before free caps, NOT
-   ~7-8¢/site that an Atmosphere-inclusive call would produce.
-
-   Captured in the candidate matrix above (row 4, updated this pass) and
-   in the ADR's Outcome A (action item: explicit field mask excluding
-   `reviews`/`reviewSummary`). Captured in `scripts/probe_reviews.py`'s
-   `ESTIMATED_CENTS_PER_CALL["google_places_new_enterprise"]` setting of
-   6 cents (Text Search + Details Enterprise + rounding margin).
-
-2. **Direct vote against Outcome E (remove the reviews provider).**
-   GPT explicitly frames Google-backed review + rating signals as
-   *"the closest thing I found to an irreplaceable signal in the
-   current value stack"* and ranks them "High" partner-utility in a
-   table where homepage/about/services extraction is "Low to medium"
-   and deterministic JSON is "Medium to low."
-
-   This is the most direct external push-back this doc has received
-   against the Outcome-E branch (remove `reviews_google_places`
-   entirely and document the agentic pattern). It is worth engaging
-   with seriously rather than dismissing as scope-drift, because if
-   GPT's framing is right, removing the reviews provider collapses the
-   one capability the product has that is not a commodity.
-
-   **The tension this doc holds:**
-
-   - GPT's "irreplaceable signal" claim is an *a priori* argument — it
-     assumes Google Places is the only way to get rating + count
-     reliably. Outcome E's precondition is that **WebSearch + LLM
-     parsing hits the same signal at 85%+ coverage with JSON-format
-     10/10 compliance**, meaning the signal stops being irreplaceable.
-     The two framings are not in conflict — they are bets on different
-     empirical questions.
-   - GPT's argument dominates if the probe shows WebSearch+parse below
-     the Outcome-E thresholds. GPT's argument fails if the probe shows
-     WebSearch+parse above them.
-   - The pre-registered decision rule already encodes this: Outcome E
-     triggers only on specific empirical thresholds, and Outcome A
-     (migrate-in-place to Google New Enterprise) is the fallback if
-     those thresholds don't clear. **GPT's pass is essentially an
-     argument that the probe will not clear those thresholds and
-     Outcome A will win.** That's a prediction about probe results,
-     not a disagreement with the decision rule.
-
-   The ADR's Outcome A is tightened this pass to name the exact
-   field-mask discipline GPT's analysis implies: request `id`,
-   `displayName`, `rating`, `userRatingCount`, `websiteUri` — nothing
-   else. That keeps Outcome A at 5.5¢/site, not the ~7.5¢/site a
-   naive Atmosphere-inclusive call would produce.
-
-### Additions taken from the external passes
-
-- **Foursquare Places API** added to the matrix above as an evaluated
-  alternative (deferred, not a Slice B finalist — Grok Pass 2 surfaced
-  this).
-- **30-day cache TTL** promoted to a cross-cutting optimization note,
-  below. Grok surfaced the idea; **Gemini's Google Maps Platform ToS
-  citation sharpens the constraint**: Google permits temporary caching
-  of Places data for up to 30 consecutive calendar days; persistent
-  local stores past that window violate the ToS. This happens to be
-  exactly the TTL Grok proposed, which lands the cache proposal on the
-  right side of the ToS line by coincidence. This doc's Vertical Memory
-  cache (SQLite) can apply this TTL directly; Slice B keeps the cache
-  disabled so per-call cost is measured honestly.
-- **2026 SKU free-tier caps** (Essentials 10k/mo free, Pro 5k/mo free)
-  — at partner 3k/mo volume, Text Search Pro stays inside the 5k/mo
-  free cap so the effective Google cost is only the Enterprise Place
-  Details leg.
-- **Apify `compass/crawler-google-places` usage stats** — 24,000+ MAU,
-  4.7/5 rating, 1.6-day average issue response (per Gemini citation [9]).
-  Stronger maintenance signal than the first draft of this doc cited;
-  reinforces the Slot #2 choice.
-- **Yelp Fusion $229/month base minimum** — Gemini citation [27].
-  Post-trial economics are worse than this doc initially stated;
-  captured in the matrix note.
-- **hiQ Labs v. LinkedIn + CFAA jurisprudence framing** — Gemini
-  citations [38–40]. Not taken into the doc verbatim (legal-framework
-  summaries age poorly and the doc doesn't need to relitigate Ninth
-  Circuit caselaw), but captured in the archive for the implementation
-  follow-up issue.
-
-### What none of the external passes covered
-
-- **WebSearch + LLM parsing as a candidate.** None of Grok-1, Grok-2,
-  or Gemini surfaced the agentic alternative. That candidate came from
-  Devon's skeptical question on the issue thread — not a desktop-
-  research category any of the LLMs spontaneously considered. This is
-  itself a signal: the alternatives external LLMs generate are the
-  alternatives that *look like the incumbent* (more structured APIs).
-  The most consequential candidate in this survey was surfaced by a
-  human who stepped outside the "what replaces the API?" frame. Noted
-  for the process record.
-- **DataForSEO Google Reviews API.** Surfaced cross-issue from the
-  COX-63 audit; none of the three external passes named this one
-  independently.
-- **Google Places Legacy's non-enablable-since-2025-03-01 status.**
-  None of the three passes flagged this. It is the single largest
-  migration-force acting on this decision independent of cost, and
-  pure desktop survey missed it. This doc catches it in Context #1 of
-  the ADR.
-
-### Foursquare — deferred alternative
+## Foursquare — deferred alternative
 
 | Method | Cost/call (est.) | Fields | ToS | Notes |
 |---|---|---|---|---|
 | **Foursquare Places API** (Pro tier) | ~1.5¢; 10k/mo free | `rating` (0–10 scale), `tips` count, categories | First-party; clean | Different reviewer pool than Google — ratings do not compare 1:1. Useful as a diversity source or review-coverage backfill, not as a cost-replacement for a Google-agreement comparison. Skipped from Slice B probe to preserve the $15 envelope. Reopen if Slice B lands in Outcome D and we widen the shortlist. |
 
-### Cross-cutting: caching strategy
-
-Independent of the provider winner, the v0.3 Vertical Memory SQLite cache
-(`docs/ARCHITECTURE.md`) is already provider-agnostic. Reviews change
-slowly enough that a 30-day TTL on `reviews_*` entries would let the
-partner's steady-state request mix hit cache on most repeat sites and pay
-the provider cost only on net-new prospects. Cache-enabled effective
-cost at 3k/mo new-prospect volume with ~20% repeat rate is roughly 80%
-of the provider's nominal cost. Grok Pass 2 raised this as a major
-cost-reduction lever and the point stands regardless of which finalist
-wins the Slice B probe. Tracked as a separate optimization, not as a
-Slice B acceptance criterion — caching under-counts the measured
-per-call cost we need to compare providers on, so the Slice B probe
-runs with caching disabled. The cache becomes an additional value layer
-on top of whichever provider ships.
-
 ## References
 
 - Issue: [#116](https://github.com/dmthepm/companyctx/issues/116)
 - Linked ADR: `decisions/2026-04-23-reviews-provider-selection.md` (status: **proposed**)
-- Prior art: `noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md` (private)
-- External LLM parallel passes: Grok (passes 1 + 2), Gemini (single long-form pass with Works Cited), and GPT (deep-research mode, overlap with COX-63 scope), all preserved verbatim in the private research archive outside this repo. Paths deliberately omitted to honor the "never create companyctx imports or paths to noontide-projects" rule. Cross-reference + critique in the "Cross-reference: external LLM research passes" section above.
-- Partner posture: `new-signal-studio/logs/d100-run-*.md` (private)
 - Pattern precedent: `research/2026-04-21-tls-impersonation-spike.md`
+- Architecture context for caching and Vertical Memory:
+  `docs/ARCHITECTURE.md`

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -292,10 +292,123 @@ double-counts the signal.
   — appended by the harness; sanitized (slugs only, no hostnames).
 - **Credentials:** operator-provided env vars, never committed.
 
+## Cross-reference: external LLM research pass
+
+Devon gave the same COX-64 prompt in parallel to Grok. Grok produced two
+passes (Pass 1, then a "deeper" Pass 2 that supersedes Pass 1). Both are
+preserved verbatim in the private research archive outside this repo for
+the diff of record. This section reconciles them against the decisions
+above.
+
+### Convergences (both passes agree with this doc)
+
+- **The cost delta is real.** Both passes land on ~10–20× between
+  first-party (Google) and scraper-family (Apify / Outscraper) at the
+  partner's ~3k/mo volume. This doc's math agrees.
+- **Apify `compass/crawler-google-places` is a legitimate scraper-family
+  finalist.** Grok names it explicitly; this doc probes it.
+- **ProviderBase pluggability is free from an architectural standpoint.**
+  Both agree that adding or swapping a reviews provider is a provider
+  entry-point change, not a schema or core-loop change.
+- **Caching makes the winner cheaper regardless.** Reviews are slow-
+  changing; a TTL'd cache of any provider's output shifts the effective
+  cost toward zero. See the new "Cross-cutting: caching" subsection below.
+
+### Divergences — where this doc holds its line
+
+1. **Google SKU field-tier mapping.** Both Grok passes collapse the
+   Essentials / Pro / Enterprise distinction and propose "Google Places
+   Essentials + field mask" as the cost-optimized Google path. The
+   authoritative Google docs place `rating`, `userRatingCount`,
+   `websiteUri`, and `regularOpeningHours` in the **Enterprise** Place
+   Details SKU, not Essentials or Pro. Essentials returns address /
+   location / types only; Pro adds display-name, phone, hours —
+   still no rating. The "Essentials with field mask" path does not
+   return the fields we need. This doc's Enterprise-tier probe slot is
+   correct; Grok's "Essentials-stays-free" framing is not.
+2. **SerpAPI.** Grok Pass 2 lists SerpApi Google Maps at $0.025+ as a
+   viable option without mention of Google's December-2025 DMCA suit
+   (motion-to-dismiss hearing 2026-05-19). This doc eliminates SerpAPI
+   pre-probe on that litigation risk; the miss in Grok's pass is an
+   example of why adversarial critique is a distinct step from desktop
+   survey. Load-bearing legal risk can hide from a single-pass
+   literature review.
+3. **ToS weighting.** Grok Pass 2 frames scraper-ToS risk as "overblown
+   ... no major enforcement actions reported in 2025–2026 against these
+   platforms for low-volume B2B use." That's true for the **act of
+   scraping**; it elides the **redistribution** axis — the partner's
+   reports ship scraped Google data to downstream cold-outreach targets,
+   which is where Google's ToS posture gets more hostile. This doc
+   weights ToS at 3× (up from the issue's 2×) for that reason. Grok
+   treats it at 2× with an "acceptable at this volume" caveat.
+4. **Recommendation shape.** Grok Pass 2 recommends "pluggable provider,
+   default to Outscraper, Google fallback." This doc (and the linked
+   ADR) explicitly rejects pluggable-as-default per the adversarial
+   critique that pluggability is maintenance debt dressed as
+   flexibility — doubled fixture sets, doubled CI-matrix cells, doubled
+   ToS surfaces, and it forces the partner to pick when the partner's
+   actual need is "rating + count shows up." Grok's suggestion and the
+   adversarial critique's rebuttal are both preserved in the record;
+   the Slice B probe numbers + the pre-registered decision rule pick
+   the outcome, not either narrative.
+5. **Grok Pass 2's factual claim that `reviews_google_places` was
+   "scaffolded but never implemented" is wrong.** The provider ships in
+   v0.3.0 and is live on `main` at 533 lines
+   (`companyctx/providers/reviews_google_places.py`), with a 572-line
+   test file, an entry point at `pyproject.toml:60`, and fixtures under
+   `fixtures/<slug>/google_places.json`. Grok Pass 1 had this right;
+   Pass 2 regressed. The error is worth flagging not to dunk on the
+   external pass but because it is a **concrete example** of why the
+   repo rule "never name a vendor in public docs before measurement"
+   exists. Narrative research that doesn't bottom out on read-the-code
+   can invent load-bearing facts in either direction.
+
+### Additions taken from Grok's passes
+
+- **Foursquare Places API** added to the matrix below as an evaluated
+  alternative (deferred, not a Slice B finalist). Foursquare brings a
+  different reviewer pool (not 1:1 with Google — different absolute
+  numbers, correlated trend), so it trades data-consistency vs. Google
+  for data-diversity. Out of scope for the Slice B probe's "cost vs.
+  Google baseline" question, but a real first-party ToS-clean option
+  if we ever need review-source diversity (e.g., non-US expansion or
+  Google-ZERO_RESULTS edge cases).
+- **30-day cache TTL** promoted from "hybrid idea" to a cross-cutting
+  optimization note, below.
+- **2026 SKU free-tier caps** (Essentials 10k/mo free, Pro 5k/mo free)
+  taken as additional evidence in the cost math: at the partner's 3k/mo
+  Text Search volume, the Pro SKU Text Search stays inside the 5k/mo
+  free cap so the effective cost is only the Enterprise Place Details
+  leg (~2.5¢/call). This narrows the Google New Enterprise vs. Apify
+  delta versus the 10–20× figure Grok's passes quote.
+
+### Foursquare — deferred alternative
+
+| Method | Cost/call (est.) | Fields | ToS | Notes |
+|---|---|---|---|---|
+| **Foursquare Places API** (Pro tier) | ~1.5¢; 10k/mo free | `rating` (0–10 scale), `tips` count, categories | First-party; clean | Different reviewer pool than Google — ratings do not compare 1:1. Useful as a diversity source or review-coverage backfill, not as a cost-replacement for a Google-agreement comparison. Skipped from Slice B probe to preserve the $15 envelope. Reopen if Slice B lands in Outcome D and we widen the shortlist. |
+
+### Cross-cutting: caching strategy
+
+Independent of the provider winner, the v0.3 Vertical Memory SQLite cache
+(`docs/ARCHITECTURE.md`) is already provider-agnostic. Reviews change
+slowly enough that a 30-day TTL on `reviews_*` entries would let the
+partner's steady-state request mix hit cache on most repeat sites and pay
+the provider cost only on net-new prospects. Cache-enabled effective
+cost at 3k/mo new-prospect volume with ~20% repeat rate is roughly 80%
+of the provider's nominal cost. Grok Pass 2 raised this as a major
+cost-reduction lever and the point stands regardless of which finalist
+wins the Slice B probe. Tracked as a separate optimization, not as a
+Slice B acceptance criterion — caching under-counts the measured
+per-call cost we need to compare providers on, so the Slice B probe
+runs with caching disabled. The cache becomes an additional value layer
+on top of whichever provider ships.
+
 ## References
 
 - Issue: [#116](https://github.com/dmthepm/companyctx/issues/116)
 - Linked ADR: `decisions/2026-04-23-reviews-provider-selection.md` (status: **proposed**)
 - Prior art: `noontide-projects/research/2026-04-20-research-pack-reviews-business-claude-code.md` (private)
+- External LLM parallel pass: Grok passes 1 + 2 preserved in the private research archive outside this repo (per the noontide-projects split; not referenced by path here to honor the "never create companyctx imports or paths to noontide-projects" rule)
 - Partner posture: `new-signal-studio/logs/d100-run-*.md` (private)
 - Pattern precedent: `research/2026-04-21-tls-impersonation-spike.md`

--- a/research/2026-04-23-reviews-extraction-method-survey.md
+++ b/research/2026-04-23-reviews-extraction-method-survey.md
@@ -15,7 +15,7 @@ raw_evidence: research/2026-04-23-reviews-probe-raw.jsonl
 
 ## One-sentence summary
 
-Across eight candidate methods surveyed desktop-only (no live probe yet), the **three finalists that go forward into the Slice B live probe** are **Google Places API (New) Enterprise SKU** (first-party, authoritative, migration target for our legacy integration), **Yelp Fusion Plus** (first-party, $9.99/1k, free at partner volume during 30-day trial, US-only but matches the partner corpus), and **Apify `compass/crawler-google-places`** (lowest nominal cost but carries post-Feb-2026 scraper fragility + residential-proxy surcharge that this doc flags honestly); SerpAPI is eliminated pre-probe on active Google DMCA litigation (Dec 2025), Google Places Essentials is eliminated because the fields we need (`rating`, `userRatingCount`) are in the Enterprise tier of the New API, Outscraper is eliminated as it wraps the same scraped-Google data as Apify without adding control, BrightData is eliminated on setup friction for a pipx CLI user, and direct Yelp scraping is eliminated on ToS posture.
+Across thirteen candidate methods surveyed desktop-only (no live probe yet), the **five finalists that go forward into the Slice B live probe** are **Google Places API (New) Enterprise SKU** (first-party baseline), **Apify `compass/crawler-google-places`** (scraper-actor category, probe measures effective cost including residential-proxy surcharge), **WebSearch + LLM parsing** (the agentic alternative — the outcome if this wins is "remove `reviews_google_places` entirely and document the pattern in `examples/`"), **DataForSEO Google Reviews API** (aggregator-family, claimed ~$0.00075/10 reviews pending 2026-pricing verification), and **Yelp Fusion Plus** (first-party US-only backup, free during 30-day trial, first-to-drop if Slice B budget tightens); SerpAPI is eliminated pre-probe on active Google DMCA litigation (Dec 2025), Google Places Essentials/Pro are eliminated because the fields we need (`rating`, `userRatingCount`) are in the Enterprise tier, Outscraper is eliminated as it wraps the same scraped-Google data as Apify without adding control, BrightData is eliminated on setup friction, and direct Yelp scraping is eliminated on ToS posture.
 
 ## Scope
 
@@ -67,9 +67,17 @@ Distilled from the partner's pipeline logs
 
 ## Candidate matrix (desktop)
 
-Eight method categories, scored on the axes named in the issue (cost,
-coverage, data shape, ToS, maintenance). Scores are desktop-only signals;
-probe numbers replace them in Slice B.
+Thirteen method categories, scored on the axes named in the issue (cost,
+coverage, data shape, ToS, maintenance). The original eight categories
+in the issue body have been expanded twice during thread review: the
+**WebSearch + LLM parsing** agentic alternative was added per Devon's
+2026-04-23 comment ("is Claude somehow finding reviews and counts just
+with web..."), and **DataForSEO Google Reviews API** was added per the
+cross-issue prompt from the COX-63 parallel audit. Both are load-bearing
+additions — one reframes the decision ("do we need a provider at all?"),
+the other adds a materially cheaper aggregator candidate that slots
+cleanly between scraper-family and first-party. Scores are desktop-only
+signals; probe numbers replace them in Slice B.
 
 | # | Method | Type | Cost/call (estimate) | Rating+count returned? | ToS posture | Maintenance signal | Status |
 |---|---|---|---|---|---|---|---|
@@ -83,8 +91,9 @@ probe numbers replace them in Slice B.
 | 8 | **Yelp Fusion Plus** | First-party API | ~$9.99/1k = 1¢/call; 30-day free trial; 500 calls/day cap | Yes (rating, review_count, 3 excerpts) | **Clean (first-party)** | Active; Jul-2024 pricing change controversy subsided | **Finalist — probe slot #2** |
 | 9 | **BrightData Web Scraper IDE** (Yelp/Google) | Enterprise scraping | Custom + proxy usage | Yes (configurable) | Gray | Active but enterprise | **Eliminated pre-probe** — setup friction incompatible with pipx-CLI user |
 | 10 | **SerpAPI Google Maps** | SERP wrapper | ~1.5¢/call effective | Yes | **Active Google DMCA lawsuit filed Dec-2025** (motion-to-dismiss hearing 2026-05-19) | Active but legally contested | **Eliminated pre-probe** — naming SerpAPI in a public OSS ADR during live Google litigation is a ship-and-regret risk. Reconsider post-ruling. |
-| 11 | **DataForSEO Google Maps** | Aggregator API | Pay-as-you-go, ~$50/mo entry; Maps SERP variable | Yes | Cleaner than SerpAPI (no active litigation on file); still relies on scraped data | Active enterprise | Evaluated; not finalist (insufficient pricing transparency for a 10-site probe, adds a fourth provider beyond the $15 budget envelope) |
+| 11 | **DataForSEO Google Reviews API** | Aggregator API | ~$0.00075 / 10 reviews ≈ sub-0.1¢/site at typical SMB review counts (claim from cross-issue Grok audit; **requires 2026-pricing verification in Slice B**) | Yes (rating + review_count + review text) | Aggregator; no active litigation on file (distinct from SerpAPI); relies on scraped data but at one abstraction layer further than direct Apify | Active enterprise, pay-as-you-go | **Finalist — probe slot #5**. Surfaced from the COX-63 parallel audit comment; claimed 10–60× cheaper than Legacy Google Places if pricing holds. |
 | 12 | **Direct Yelp page scraping** | Homebrew | ~0¢ (proxy costs) | Yes | **Yelp ToS explicitly prohibits** | N/A | **Eliminated** — named for completeness only; would never ship |
+| 13 | **WebSearch + LLM parsing** (agentic) | Agent-tool pattern (no dedicated provider) | ~$0.01–0.02/query (Claude/Anthropic search-tool pricing) + agent parse tokens | Yes (rating + review_count reliably from SERP cards; snippets sometimes; categories inconsistently) | Clean — it's an agent using its own tool surface, not scraping Google directly | N/A (no provider module to maintain) | **Finalist — probe slot #4**. The most consequential candidate: if this wins on the partner corpus, the outcome is "remove `reviews_google_places` entirely and document the agentic pattern" (ADR Outcome E). |
 
 ### Eliminations, reasoned
 
@@ -114,20 +123,17 @@ probe numbers replace them in Slice B.
 
 ### Finalists — probe slot justification
 
+Five slots × 10 sites = 50 cells. Budget estimate: ~$1.50 total (well
+inside the $5–15 envelope), making room for all five without forcing a
+triage.
+
 **Slot #1: Google Places API (New) Enterprise.** First-party,
 authoritative rating, migration target for our legacy integration (which
 Google has flagged as non-enablable for new projects since 2025-03-01).
 Even if we decide to switch the default, the Enterprise SKU becomes the
 ToS-clean escape hatch. Must be measured.
 
-**Slot #2: Yelp Fusion Plus.** First-party, US-only (matches partner
-corpus — medical-aesthetic and home-services are US-heavy), 500 calls/day
-cap is above the partner's 100/day volume so the 30-day trial is
-effectively free, $9.99/1k thereafter is cheaper than Google New
-Enterprise. Honest coverage gap: businesses not listed on Yelp at all
-(more common in home-services than aesthetic). Must be measured.
-
-**Slot #3: Apify `compass/crawler-google-places`.** The scraper-actor
+**Slot #2: Apify `compass/crawler-google-places`.** The scraper-actor
 category the issue specifically asks about. Most-used Google Maps actor
 on Apify (`compass/` prefix is Apify's most-maintained third-party
 namespace). Headline price ~$2.10/1k looks like a 20× savings over
@@ -136,6 +142,41 @@ residential proxies** (the Feb-2026 limited-view rollout broke most
 legacy scrapers and survivors need residential-proxy rotation). If the
 effective cost lands above ~2¢/call the advantage evaporates. Must be
 measured.
+
+**Slot #3: WebSearch + LLM parsing.** The agentic alternative surfaced
+by Devon's 2026-04-23 skeptical push: *"is Claude somehow finding
+reviews and counts just with web..."* The partner's pipeline already
+drives Claude through research passes; if a single WebSearch turn on
+`"<business name> <city> reviews"` reliably surfaces Google's structured
+SERP result card (which typically contains rating + user_ratings_total
+inline) for 85%+ of the partner corpus, then `reviews_google_places` at
+5.4¢/site is paying for determinism the downstream pipeline may not
+need. This is the **most consequential slot** — it's the one where
+"win" means "remove the provider entirely, document the pattern, ship
+v0.5 with one fewer dependency to maintain." Must be measured.
+
+**Slot #4: DataForSEO Google Reviews API.** The aggregator-family
+candidate added per the COX-63 audit comment. Claimed ~$0.00075/10
+reviews — if the April-2026 pricing still holds, effective cost on a
+typical SMB (10–50 reviews per business) is sub-0.1¢/site, which would
+make it the cheapest non-agentic option by an order of magnitude. Sits
+between first-party (Google, Yelp) and scraper-direct (Apify) on both
+the cost axis and the ToS axis: aggregation at one abstraction layer
+further from Google's terms-of-service frontline than Apify, with no
+active-litigation signal on file. Slice B's first task on this slot is
+to **verify the pricing claim** against DataForSEO's current pricing
+page before burning any probe cells on it. Must be measured.
+
+**Slot #5: Yelp Fusion Plus.** First-party, US-only (matches partner
+corpus — medical-aesthetic and home-services are US-heavy), 500
+calls/day cap is above the partner's 100/day volume so the 30-day trial
+is effectively free, $9.99/1k thereafter is cheaper than Google New
+Enterprise. Honest coverage gap: businesses not listed on Yelp at all
+(more common in home-services than aesthetic). **First-to-drop if Slice
+B budget or wall-clock tightens** — the partner's own pipeline already
+runs Yelp as an out-of-band fallback, so the question "does Yelp cover
+where Google doesn't?" is partially answered by new-signal-studio's
+operational record already. Must be measured if budget allows.
 
 (Apify also has cheaper newer actors — e.g. `kaix/google-maps-places-scraper`
 at ~$0.10/1k nominal — but they have far lower monthly-user counts
@@ -173,7 +214,7 @@ per cell. Row shape:
 ```json
 {
   "slug": "med-aesth-01",
-  "provider": "google_places_new_enterprise | yelp_fusion_plus | apify_compass_crawler",
+  "provider": "google_places_new_enterprise | apify_compass_crawler | websearch_llm_parse | dataforseo_reviews | yelp_fusion_plus",
   "run_id": "2026-04-23-<uuid4>",
   "run_date": "2026-04-23",
   "status": "ok | zero_results | blocked | error",
@@ -190,9 +231,47 @@ per cell. Row shape:
 }
 ```
 
-Provider credentials live in the operator's local env (`GOOGLE_PLACES_API_KEY`,
-`YELP_FUSION_API_KEY`, `APIFY_TOKEN`) and are never committed. The harness
-is provider-agnostic: adding a fourth provider is one adapter class.
+Provider credentials live in the operator's local env (`GOOGLE_PLACES_NEW_API_KEY`,
+`YELP_FUSION_API_KEY`, `APIFY_TOKEN`, `DATAFORSEO_LOGIN` + `DATAFORSEO_PASSWORD`)
+and are never committed. The harness is provider-agnostic: adding a new
+provider is one adapter class.
+
+### WebSearch + LLM parsing: agentic-probe protocol
+
+Slot #3 is structurally different from the other four slots — it is an
+agent-tool pattern, not a billable third-party API. The probe harness
+cannot "just call" WebSearch+parse the way it calls a REST endpoint;
+the call surface is Claude's own tool use, driven by a prompt.
+
+The operator runs the agentic probe out-of-band, producing JSONL rows
+that match the shared schema above. Protocol:
+
+1. For each slug, the operator opens a fresh Claude Code session (or
+   programmatic API call to `claude-opus-4-7` with WebSearch tool
+   enabled) and runs a pre-registered prompt template of the shape:
+   ```
+   Find the Google rating and review count for "<business name> <city>".
+   Use WebSearch. Return exactly a JSON object with keys rating (float
+   or null), review_count (int or null), source (string identifying
+   where the number came from: SERP-card | yelp-SERP | facebook-SERP |
+   other | not-found). Do not invent numbers.
+   ```
+2. The operator records the session's `input_tokens`, `output_tokens`,
+   `tool_use.web_search.queries`, and the returned JSON. Billed cost is
+   computed from the token counts × the model's price plus the
+   WebSearch tool's per-query cost.
+3. Latency is the wall-clock time from prompt-submit to final
+   assistant turn (the session, not any single tool call).
+4. The JSON is appended to the probe-raw JSONL with
+   `provider: "websearch_llm_parse"`.
+
+Determinism caveat: the agentic slot runs once per slug, not N-repeats.
+LLM outputs vary; the probe captures a single trial, not a distribution.
+If the WebSearch+parse slot is the eventual winner, the Slice B ADR
+must document this sampling caveat and an implementation ticket must
+specify how downstream agentic consumers handle variance (temperature
+pin, few-shot examples, retry-on-nonconforming-JSON — all downstream
+concerns, out of scope for the measurement).
 
 ### Site mix: why 10 and not 100
 
@@ -217,31 +296,53 @@ divergent one; that's a Slice B branch, not a Slice A commitment.
 ### Decision rule (pre-committed)
 
 The recommendation after the probe follows this rule, pre-registered
-before measurement to avoid motivated interpretation:
+before measurement to avoid motivated interpretation. Order matters —
+the first matching branch wins, which prioritizes the provider-removal
+outcome when it is supportable over keeping an expensive dedicated
+provider:
 
 ```
 effective_cost_per_successful_call(p) =
-    (nominal_cost_cents(p) + proxy_cost_cents(p) + actor_start_cents(p))
+    (nominal_cost_cents(p) + proxy_cost_cents(p) + actor_start_cents(p)
+     + agent_token_cents(p))
     / coverage_rate(p)
 
-Recommend KEEP Google Places (migrate Legacy → New Enterprise) if:
-    effective_cost(google_new_enterprise) ≤ 1.5 × effective_cost(cheapest_other)
-    AND coverage(google_new_enterprise) ≥ 0.8
+Recommend REMOVE provider entirely (agentic pattern) if:
+    coverage(websearch_llm_parse) ≥ 0.85
+    AND effective_cost(websearch_llm_parse) ≤ 1.5¢/site
+    AND data consistency vs Google baseline within ±0.3 stars on
+        co-present businesses
+    AND the JSON-format compliance rate across the 10 slugs is 10/10
+        (no hallucinated numbers, no malformed outputs)
+
+Recommend SWITCH to cheapest aggregator if:
+    coverage(dataforseo_reviews) ≥ 0.85
+    AND effective_cost(dataforseo_reviews) ≤ 0.5 × effective_cost(google_new_enterprise)
+    AND 2026-pricing verification confirms the sub-0.1¢/site claim
+    AND data consistency vs Google baseline within ±0.3 stars
+
+Recommend SWITCH to cheapest viable first-party/gold-tier alternative if:
+    effective_cost(cheapest) < 0.5 × effective_cost(google_new_enterprise)
+    AND coverage(cheapest) ≥ coverage(google_new_enterprise) - 0.05
+    AND ToS posture is first-party or Gold-tier Apify actor
 
 Recommend COMPOSITE (Google New Enterprise → Yelp Fusion fallback) if:
     coverage(google_new_enterprise) < 0.8
     AND coverage(google OR yelp) ≥ 0.9
     AND effective_cost(composite_expected) ≤ 1.2 × effective_cost(google_only)
 
-Recommend SWITCH to cheapest viable if:
-    effective_cost(cheapest) < 0.5 × effective_cost(google_new_enterprise)
-    AND coverage(cheapest) ≥ coverage(google_new_enterprise) - 0.05
-    AND ToS posture is first-party or Gold-tier Apify actor
+Recommend KEEP Google Places (migrate Legacy → New Enterprise) if:
+    effective_cost(google_new_enterprise) ≤ 1.5 × effective_cost(cheapest_other)
+    AND coverage(google_new_enterprise) ≥ 0.8
 
 Else: KEEP Legacy temporarily, reopen probe with different shortlist.
 ```
 
-All three branches land in the ADR; the probe numbers pick which.
+All five branches land in the ADR (Outcomes A–E); the probe numbers
+pick which. Ordering reflects "prefer less surface area when the
+numbers support it" — removing the reviews provider entirely is the
+single highest-leverage outcome available to this spike, so it is
+first in the rule.
 
 ## Decision matrix (pre-probe, weights only)
 

--- a/scripts/probe_reviews.py
+++ b/scripts/probe_reviews.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""COX-64 Slice B — reviews-provider probe harness.
+
+Runs one call per ``(slug, provider)`` cell against the three finalists
+named in ``research/2026-04-23-reviews-extraction-method-survey.md`` and
+appends one JSONL row per cell to a raw-evidence file.
+
+Slice A (this PR) ships the harness scaffolding and the adapter
+interfaces — no network calls, no spend. Slice B (follow-up) provisions
+the API keys + Apify token + residential-proxy allocation and runs the
+harness for real.
+
+Usage (Slice B, once keys are provisioned)::
+
+    export GOOGLE_PLACES_NEW_API_KEY=...
+    export YELP_FUSION_API_KEY=...
+    export APIFY_TOKEN=...
+    python scripts/probe_reviews.py \\
+        --slugs research/.slug-map-cox64.local.csv \\
+        --providers google_places_new_enterprise yelp_fusion_plus apify_compass_crawler \\
+        --output research/2026-04-23-reviews-probe-raw.jsonl \\
+        --confirm-spend-usd 15
+
+Until ``--confirm-spend-usd`` is passed (with a value at least as large
+as the estimated cost), the harness prints the estimated spend and
+exits without making any network calls. This is the safety gate that
+keeps Slice A from accidentally spending partner money.
+
+The slug map CSV is ``slug,host,query_name`` — ``query_name`` is the
+business display-name string used for Text Search / Yelp business-match
+(the harness does **not** resolve hostnames to business names itself —
+that's the operator's job, done once when building the slug map).
+
+Output row schema (one per cell) is documented in
+``research/2026-04-23-reviews-extraction-method-survey.md#measurement-harness``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal, Protocol
+
+PROVIDER_IDS = (
+    "google_places_new_enterprise",
+    "yelp_fusion_plus",
+    "apify_compass_crawler",
+)
+ProviderId = Literal[
+    "google_places_new_enterprise",
+    "yelp_fusion_plus",
+    "apify_compass_crawler",
+]
+
+
+# Pre-probe cost estimates (cents) used only for the --confirm-spend gate.
+# These come from the desktop survey and are replaced by measured
+# ``cost_incurred_cents`` in the JSONL rows the harness emits.
+ESTIMATED_CENTS_PER_CALL: dict[str, int] = {
+    "google_places_new_enterprise": 4,  # Text Search + Details (Enterprise field mask)
+    "yelp_fusion_plus": 1,  # $9.99/1k = 1c, free during trial
+    "apify_compass_crawler": 5,  # ~$2.10/1k nominal + residential proxy
+}
+
+
+@dataclass
+class ProbeRow:
+    """One row of the probe JSONL. Shape is stable across all providers."""
+
+    slug: str
+    provider: str
+    run_id: str
+    run_date: str
+    status: Literal["ok", "zero_results", "blocked", "error"]
+    rating: float | None
+    review_count: int | None
+    data_source_name: str | None
+    latency_ms: int
+    cost_incurred_cents: int
+    proxy_used: Literal["residential", "none"] = "none"
+    raw_response_hash: str | None = None
+    notes: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+
+class ProviderAdapter(Protocol):
+    """Common interface every finalist provider adapter implements.
+
+    ``fetch`` never raises — the adapter maps all failure modes to a
+    ``ProbeRow`` with the appropriate ``status`` and ``error_*`` fields,
+    mirroring the ``ProviderBase`` contract of the runtime providers.
+    """
+
+    provider_id: str
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow: ...
+
+
+def _hash_response(obj: object) -> str:
+    """Deterministic content hash for raw-response pinning in the JSONL."""
+    payload = json.dumps(obj, sort_keys=True, default=str).encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
+
+
+def _row(
+    *,
+    slug: str,
+    provider: str,
+    status: str,
+    latency_ms: int,
+    cost_incurred_cents: int,
+    rating: float | None = None,
+    review_count: int | None = None,
+    data_source_name: str | None = None,
+    proxy_used: str = "none",
+    raw_response_hash: str | None = None,
+    notes: str | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> ProbeRow:
+    return ProbeRow(
+        slug=slug,
+        provider=provider,
+        run_id=str(uuid.uuid4()),
+        run_date=time.strftime("%Y-%m-%d"),
+        status=status,  # type: ignore[arg-type]
+        rating=rating,
+        review_count=review_count,
+        data_source_name=data_source_name,
+        latency_ms=latency_ms,
+        cost_incurred_cents=cost_incurred_cents,
+        proxy_used=proxy_used,  # type: ignore[arg-type]
+        raw_response_hash=raw_response_hash,
+        notes=notes,
+        error_code=error_code,
+        error_message=error_message,
+    )
+
+
+class GooglePlacesNewEnterpriseAdapter:
+    """Slice B — real implementation wires Places API (New) Text Search +
+    Place Details with an Enterprise-tier field mask.
+
+    Field mask must include ``rating`` and ``userRatingCount`` to trigger
+    the Enterprise SKU (that's the point of the probe — we're paying for
+    those exact fields).
+    """
+
+    provider_id = "google_places_new_enterprise"
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        # Slice-B TODO: Text Search (New) -> Place Details (New) with
+        # field_mask="id,displayName,rating,userRatingCount,websiteUri".
+        # Enforce billing-safety: fail fast if the API key is missing or
+        # the field mask is ever altered to something outside Enterprise.
+        raise NotImplementedError(
+            "Slice B implementation pending key provisioning — see "
+            "decisions/2026-04-23-reviews-provider-selection.md"
+        )
+
+
+class YelpFusionPlusAdapter:
+    """Slice B — real implementation wires /v3/businesses/search with
+    ``term`` and ``location`` derived from query_name, then the
+    /v3/businesses/{id} detail endpoint to pin rating+review_count.
+
+    The Plus tier returns 3 review excerpts; we ignore them (richness
+    weight = 1× per ADR).
+    """
+
+    provider_id = "yelp_fusion_plus"
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        raise NotImplementedError(
+            "Slice B implementation pending key provisioning — see "
+            "decisions/2026-04-23-reviews-provider-selection.md"
+        )
+
+
+class ApifyCompassCrawlerAdapter:
+    """Slice B — real implementation runs the
+    ``compass/crawler-google-places`` actor in sync mode with a
+    residential-proxy configuration and extracts
+    ``reviewsCount`` + ``totalScore`` from the first result.
+
+    Cost accounting must **include** proxy units — nominal $2.10/1k
+    Apify cost is misleading without them after the Feb-2026 Google Maps
+    limited-view event.
+    """
+
+    provider_id = "apify_compass_crawler"
+
+    def __init__(self, token: str) -> None:
+        self.token = token
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        raise NotImplementedError(
+            "Slice B implementation pending token provisioning — see "
+            "decisions/2026-04-23-reviews-provider-selection.md"
+        )
+
+
+def build_adapter(provider_id: str) -> ProviderAdapter:
+    """Instantiate the adapter for ``provider_id`` from its env var.
+
+    Env vars required (loaded by the operator before running the harness):
+
+    - ``GOOGLE_PLACES_NEW_API_KEY`` for ``google_places_new_enterprise``
+    - ``YELP_FUSION_API_KEY`` for ``yelp_fusion_plus``
+    - ``APIFY_TOKEN`` for ``apify_compass_crawler``
+    """
+    if provider_id == "google_places_new_enterprise":
+        key = os.environ.get("GOOGLE_PLACES_NEW_API_KEY")
+        if not key:
+            raise SystemExit(
+                "GOOGLE_PLACES_NEW_API_KEY is not set — "
+                "provision via Google Cloud Console and re-run"
+            )
+        return GooglePlacesNewEnterpriseAdapter(api_key=key)
+    if provider_id == "yelp_fusion_plus":
+        key = os.environ.get("YELP_FUSION_API_KEY")
+        if not key:
+            raise SystemExit(
+                "YELP_FUSION_API_KEY is not set — "
+                "provision via Yelp Data Licensing signup and re-run"
+            )
+        return YelpFusionPlusAdapter(api_key=key)
+    if provider_id == "apify_compass_crawler":
+        token = os.environ.get("APIFY_TOKEN")
+        if not token:
+            raise SystemExit("APIFY_TOKEN is not set — provision via Apify console and re-run")
+        return ApifyCompassCrawlerAdapter(token=token)
+    raise SystemExit(f"unknown provider_id: {provider_id}")
+
+
+def load_slug_map(path: Path) -> list[tuple[str, str, str]]:
+    """Parse the gitignored ``slug,host,query_name`` CSV.
+
+    The map lives at ``research/.slug-map-cox64.local.csv`` by convention
+    so it never leaks the partner's seed list into public git history.
+    """
+    if not path.exists():
+        raise SystemExit(
+            f"slug map not found at {path}. Build it by sampling "
+            "deterministically from the 209-site v0.4 corpus "
+            "(4 medical-aesthetic, 3 home-services, "
+            "2 no-website-just-Facebook, 1 obscure)."
+        )
+    rows: list[tuple[str, str, str]] = []
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            rows.append((row["slug"], row["host"], row["query_name"]))
+    return rows
+
+
+def estimate_spend_cents(
+    slugs: list[tuple[str, str, str]],
+    providers: list[str],
+) -> int:
+    """Conservative pre-flight estimate. Replaced by measured billed
+    ``cost_incurred_cents`` after the probe runs."""
+    per_cell = sum(ESTIMATED_CENTS_PER_CALL[p] for p in providers)
+    return per_cell * len(slugs)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--slugs",
+        type=Path,
+        required=True,
+        help="CSV with columns slug,host,query_name (gitignored .local.*)",
+    )
+    ap.add_argument(
+        "--providers",
+        nargs="+",
+        default=list(PROVIDER_IDS),
+        choices=list(PROVIDER_IDS),
+        help="Provider subset to probe",
+    )
+    ap.add_argument(
+        "--output",
+        type=Path,
+        default=Path("research/2026-04-23-reviews-probe-raw.jsonl"),
+        help="JSONL output path",
+    )
+    ap.add_argument(
+        "--confirm-spend-usd",
+        type=float,
+        default=0.0,
+        help=(
+            "Confirm authorization to spend up to $N on this probe. "
+            "Harness refuses to make network calls until this equals or "
+            "exceeds the pre-flight estimate. Default 0 = dry-run."
+        ),
+    )
+    ap.add_argument(
+        "--pacing-s",
+        type=float,
+        default=2.0,
+        help="Sleep between cells to avoid rate-limit surprises",
+    )
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    slugs = load_slug_map(args.slugs)
+    providers: list[str] = args.providers
+    estimated_cents = estimate_spend_cents(slugs, providers)
+    estimated_usd = estimated_cents / 100.0
+    print(
+        f"Probe preflight: {len(slugs)} slugs × {len(providers)} providers "
+        f"= {len(slugs) * len(providers)} cells, "
+        f"estimated spend ${estimated_usd:.2f}",
+        file=sys.stderr,
+    )
+    if args.confirm_spend_usd < estimated_usd:
+        print(
+            f"Dry-run: --confirm-spend-usd={args.confirm_spend_usd:.2f} < "
+            f"estimated ${estimated_usd:.2f}. No network calls made.",
+            file=sys.stderr,
+        )
+        return 0
+    adapters = [build_adapter(pid) for pid in providers]
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("a") as out:
+        for slug, host, query_name in slugs:
+            for adapter in adapters:
+                row = adapter.fetch(slug=slug, host=host, query_name=query_name)
+                out.write(json.dumps(asdict(row)) + "\n")
+                time.sleep(args.pacing_s)
+    print(f"Probe complete — rows appended to {args.output}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_reviews.py
+++ b/scripts/probe_reviews.py
@@ -112,7 +112,11 @@ class ProviderAdapter(Protocol):
 
     provider_id: str
 
-    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow: ...
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        """Fetch rating + count for ``slug``. Must never raise — map all
+        failure modes (missing key, network error, zero-result, blocked)
+        to a ``ProbeRow`` with the appropriate ``status`` and
+        ``error_*`` fields instead."""
 
 
 def _hash_response(obj: object) -> str:

--- a/scripts/probe_reviews.py
+++ b/scripts/probe_reviews.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """COX-64 Slice B — reviews-provider probe harness.
 
-Runs one call per ``(slug, provider)`` cell against the three finalists
+Runs one call per ``(slug, provider)`` cell against the five finalists
 named in ``research/2026-04-23-reviews-extraction-method-survey.md`` and
 appends one JSONL row per cell to a raw-evidence file.
 
@@ -24,7 +24,7 @@ Usage (Slice B, once keys are provisioned)::
 Until ``--confirm-spend-usd`` is passed (with a value at least as large
 as the estimated cost), the harness prints the estimated spend and
 exits without making any network calls. This is the safety gate that
-keeps Slice A from accidentally spending partner money.
+keeps Slice A from accidentally spending real money.
 
 The slug map CSV is ``slug,host,query_name`` — ``query_name`` is the
 business display-name string used for Text Search / Yelp business-match
@@ -166,7 +166,7 @@ class GooglePlacesNewEnterpriseAdapter:
 
     Requesting ``reviews`` or ``reviewSummary`` would escalate to the
     Atmosphere SKU at $25/1k instead of Enterprise at $20/1k. The
-    partner's downstream consumes rating + count only; we pay
+    default downstream consumers use rating + count only; we pay
     Enterprise, not Atmosphere.
 
     Expected billed cost per successful cell: Text Search Enterprise
@@ -344,14 +344,14 @@ def load_slug_map(path: Path) -> list[tuple[str, str, str]]:
     """Parse the gitignored ``slug,host,query_name`` CSV.
 
     The map lives at ``research/.slug-map-cox64.local.csv`` by convention
-    so it never leaks the partner's seed list into public git history.
+    so real hostnames never leak into public git history.
     """
     if not path.exists():
         raise SystemExit(
             f"slug map not found at {path}. Build it by sampling "
-            "deterministically from the 209-site v0.4 corpus "
-            "(4 medical-aesthetic, 3 home-services, "
-            "2 no-website-just-Facebook, 1 obscure)."
+            "deterministically from the tool's historical test corpus "
+            "with category labels: 4 small-local-business, 3 "
+            "service-area-business, 2 social-only, 1 obscure."
         )
     rows: list[tuple[str, str, str]] = []
     with path.open() as fh:

--- a/scripts/probe_reviews.py
+++ b/scripts/probe_reviews.py
@@ -69,7 +69,11 @@ ProviderId = Literal[
 # These come from the desktop survey and are replaced by measured
 # ``cost_incurred_cents`` in the JSONL rows the harness emits.
 ESTIMATED_CENTS_PER_CALL: dict[str, int] = {
-    "google_places_new_enterprise": 4,  # Text Search + Details (Enterprise field mask)
+    # Text Search Enterprise $35/1k = 3.5c + Place Details Enterprise (rating,
+    # userRatingCount, websiteUri — no Atmosphere) $20/1k = 2c = 5.5c/site.
+    # 1k/mo free on each SKU, so the first 1k cells per SKU are $0. Round to
+    # 6 for probe-budget safety margin.
+    "google_places_new_enterprise": 6,
     "apify_compass_crawler": 5,  # ~$2.10/1k nominal + residential proxy
     "websearch_llm_parse": 2,  # ~1.5c WebSearch + agent tokens
     "dataforseo_reviews": 1,  # Claimed ~$0.00075/10 reviews — round up to 1c for safety
@@ -154,11 +158,22 @@ def _row(
 
 class GooglePlacesNewEnterpriseAdapter:
     """Slice B — real implementation wires Places API (New) Text Search +
-    Place Details with an Enterprise-tier field mask.
+    Place Details with an Enterprise-tier field mask that **explicitly
+    excludes Atmosphere-tier fields**.
 
-    Field mask must include ``rating`` and ``userRatingCount`` to trigger
-    the Enterprise SKU (that's the point of the probe — we're paying for
-    those exact fields).
+    Exact field mask for Place Details (New):
+    ``id,displayName,rating,userRatingCount,websiteUri``.
+
+    Requesting ``reviews`` or ``reviewSummary`` would escalate to the
+    Atmosphere SKU at $25/1k instead of Enterprise at $20/1k. The
+    partner's downstream consumes rating + count only; we pay
+    Enterprise, not Atmosphere.
+
+    Expected billed cost per successful cell: Text Search Enterprise
+    $0.035 + Place Details Enterprise $0.020 = $0.055 (5.5c). First 1k
+    cells/mo per SKU are free. The adapter must record the actual
+    billed cost from response headers / billing console, not the
+    estimate.
     """
 
     provider_id = "google_places_new_enterprise"
@@ -167,10 +182,10 @@ class GooglePlacesNewEnterpriseAdapter:
         self.api_key = api_key
 
     def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
-        # Slice-B TODO: Text Search (New) -> Place Details (New) with
-        # field_mask="id,displayName,rating,userRatingCount,websiteUri".
-        # Enforce billing-safety: fail fast if the API key is missing or
-        # the field mask is ever altered to something outside Enterprise.
+        # Slice-B TODO: Text Search (New) -> Place Details (New).
+        # Lock field mask to ``id,displayName,rating,userRatingCount,websiteUri``.
+        # Fail-fast if a future edit tries to add ``reviews`` or
+        # ``reviewSummary`` (that would silently move billing to Atmosphere).
         raise NotImplementedError(
             "Slice B implementation pending key provisioning — see "
             "decisions/2026-04-23-reviews-provider-selection.md"

--- a/scripts/probe_reviews.py
+++ b/scripts/probe_reviews.py
@@ -51,13 +51,17 @@ from typing import Literal, Protocol
 
 PROVIDER_IDS = (
     "google_places_new_enterprise",
-    "yelp_fusion_plus",
     "apify_compass_crawler",
+    "websearch_llm_parse",
+    "dataforseo_reviews",
+    "yelp_fusion_plus",
 )
 ProviderId = Literal[
     "google_places_new_enterprise",
-    "yelp_fusion_plus",
     "apify_compass_crawler",
+    "websearch_llm_parse",
+    "dataforseo_reviews",
+    "yelp_fusion_plus",
 ]
 
 
@@ -66,8 +70,10 @@ ProviderId = Literal[
 # ``cost_incurred_cents`` in the JSONL rows the harness emits.
 ESTIMATED_CENTS_PER_CALL: dict[str, int] = {
     "google_places_new_enterprise": 4,  # Text Search + Details (Enterprise field mask)
-    "yelp_fusion_plus": 1,  # $9.99/1k = 1c, free during trial
     "apify_compass_crawler": 5,  # ~$2.10/1k nominal + residential proxy
+    "websearch_llm_parse": 2,  # ~1.5c WebSearch + agent tokens
+    "dataforseo_reviews": 1,  # Claimed ~$0.00075/10 reviews — round up to 1c for safety
+    "yelp_fusion_plus": 1,  # $9.99/1k = 1c, free during trial
 }
 
 
@@ -215,14 +221,74 @@ class ApifyCompassCrawlerAdapter:
         )
 
 
+class WebSearchLlmParseAdapter:
+    """Slice B — the agentic alternative.
+
+    Structurally different from the other adapters: there is no billable
+    REST endpoint to call. The operator runs the agentic probe
+    out-of-band — one prompt per slug, driving Claude through its own
+    WebSearch tool surface — and appends JSONL rows matching this
+    harness's schema. See the "WebSearch + LLM parsing: agentic-probe
+    protocol" subsection in
+    ``research/2026-04-23-reviews-extraction-method-survey.md`` for the
+    exact prompt template, token-accounting rules, and the determinism
+    caveat (one trial per slug, not a distribution).
+
+    This adapter exists so the provider_id is first-class in the probe
+    config and the row schema stays uniform; ``fetch`` deliberately
+    raises to force the operator into the documented out-of-band
+    workflow instead of accidentally running the harness against a non-
+    existent HTTP endpoint.
+    """
+
+    provider_id = "websearch_llm_parse"
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        raise NotImplementedError(
+            "websearch_llm_parse is an agentic probe — see "
+            "research/2026-04-23-reviews-extraction-method-survey.md "
+            "for the out-of-band protocol. Append the operator-produced "
+            "rows directly to the probe JSONL."
+        )
+
+
+class DataForSeoReviewsAdapter:
+    """Slice B — real implementation wires the DataForSEO Google
+    Reviews API (``/v3/business_data/google/reviews/task_post`` +
+    ``/task_get``) with HTTP Basic auth on the login / password pair.
+
+    **First Slice B task on this slot is to verify the 2026 pricing
+    claim** (~$0.00075/10 reviews) against DataForSEO's current pricing
+    page. The ``cost_incurred_cents`` emitted by this adapter must be
+    the actual billed cost from the task-post response's ``cost`` field,
+    not a pre-registered estimate.
+    """
+
+    provider_id = "dataforseo_reviews"
+
+    def __init__(self, login: str, password: str) -> None:
+        self.login = login
+        self.password = password
+
+    def fetch(self, slug: str, host: str, query_name: str) -> ProbeRow:
+        raise NotImplementedError(
+            "Slice B implementation pending credential provisioning — "
+            "see decisions/2026-04-23-reviews-provider-selection.md"
+        )
+
+
 def build_adapter(provider_id: str) -> ProviderAdapter:
     """Instantiate the adapter for ``provider_id`` from its env var.
 
     Env vars required (loaded by the operator before running the harness):
 
     - ``GOOGLE_PLACES_NEW_API_KEY`` for ``google_places_new_enterprise``
-    - ``YELP_FUSION_API_KEY`` for ``yelp_fusion_plus``
     - ``APIFY_TOKEN`` for ``apify_compass_crawler``
+    - ``DATAFORSEO_LOGIN`` + ``DATAFORSEO_PASSWORD`` for ``dataforseo_reviews``
+    - ``YELP_FUSION_API_KEY`` for ``yelp_fusion_plus``
+    - (no env for ``websearch_llm_parse`` — that slot is an agentic
+      out-of-band probe; the adapter raises to redirect the operator
+      to the documented protocol)
     """
     if provider_id == "google_places_new_enterprise":
         key = os.environ.get("GOOGLE_PLACES_NEW_API_KEY")
@@ -245,6 +311,17 @@ def build_adapter(provider_id: str) -> ProviderAdapter:
         if not token:
             raise SystemExit("APIFY_TOKEN is not set — provision via Apify console and re-run")
         return ApifyCompassCrawlerAdapter(token=token)
+    if provider_id == "websearch_llm_parse":
+        return WebSearchLlmParseAdapter()
+    if provider_id == "dataforseo_reviews":
+        login = os.environ.get("DATAFORSEO_LOGIN")
+        password = os.environ.get("DATAFORSEO_PASSWORD")
+        if not login or not password:
+            raise SystemExit(
+                "DATAFORSEO_LOGIN and DATAFORSEO_PASSWORD must both be set — "
+                "provision via dataforseo.com signup and re-run"
+            )
+        return DataForSeoReviewsAdapter(login=login, password=password)
     raise SystemExit(f"unknown provider_id: {provider_id}")
 
 


### PR DESCRIPTION
## Summary

- Ships the Slice A deliverables for #116: a committed desktop survey of reviews-extraction methods, an ADR in `proposed` state, and a probe-harness scaffold ready for Slice B.
- Candidate matrix covers 13 methods; 5 finalists advance to the live probe (Google Places (New) Enterprise, Apify `compass/crawler-google-places`, WebSearch + LLM parsing, DataForSEO Google Reviews API, Yelp Fusion Plus). Eliminations reasoned for Essentials/Pro (missing fields), SerpAPI (Dec-2025 Google DMCA litigation), Outscraper (wraps same scraped data as Apify), BrightData (setup friction), direct Yelp scraping (ToS).
- ADR carries a five-branch outcome structure (A migrate-in-place, B switch to Yelp Fusion, C composite fallback, D reopen, **E remove the reviews provider entirely and document the agentic pattern**). Decision rule is pre-registered so the probe numbers mechanically pick the outcome.
- Outcome A's action list locks the Google Places (New) field mask to `id,displayName,rating,userRatingCount,websiteUri` — excludes Atmosphere-tier fields, keeps us at $20/1k Enterprise instead of $25/1k +Atmosphere, drops expected Google bill at 3k/mo from ~$175/mo to ~$110/mo (37% reduction).
- Slice B live probe + ADR promotion is tracked as follow-up **#119** — requires operator-provisioned keys + $5–15 authorized spend.

## Commits

- `4cacd3c` — docs(research): COX-64 Slice A reviews-extraction method survey
- `3635f99` — docs(decision): COX-64 reviews-provider selection ADR (proposed)
- `8b947b9` — chore(scripts): add COX-64 Slice B probe harness scaffolding
- `b55e169` — docs(research): synthesize external Grok research pass into COX-64 survey
- `8df2b6e` — docs(research,decision,scripts): add WebSearch+parse and DataForSEO as COX-64 finalists
- `4adced4` — docs(research): re-synthesize external LLM passes — add Gemini's Works-Cited pass
- `6358b13` — docs(research,decision,scripts): integrate GPT deep-research pass — Enterprise field-mask discipline
- `ed74af2` — docs(research,decision,scripts): sanitize COX-64 deliverables to public/private boundary

## Acceptance (from #116)

- [x] Research doc with candidate matrix + decision matrix + recommendation framework — `research/2026-04-23-reviews-extraction-method-survey.md`
- [x] ADR committed with rationale — `decisions/2026-04-23-reviews-provider-selection.md` (status: **`proposed`**, per the precedent ADR pattern — `accepted` only after the measurement spike)
- [x] Zero sanitization leaks (all three committed files verified clean: no `noontide-projects`, `new-signal-studio`, partner-workflow specifics, or external-LLM vendor attribution in the public artifacts)
- [x] Implementation follow-up issue opened if switching — Slice B follow-up **#119** opened; covers probe execution, ADR promotion, and any Outcome A/B/C/E implementation
- [ ] **10-site probe results** — deferred to Slice B **#119** (requires operator-provisioned keys + $5–15 spend, out of agent-session authorization scope)
- [ ] **ADR promotion to `accepted`** — deferred to Slice B (repo pattern: "accepted" only after measurement)
- [ ] **Total probe spend $5–15** — deferred to Slice B
- [x] CI green

## Test plan

- [x] `ruff format --check .` clean (reported by branch-author)
- [x] `ruff check .` clean (reported by branch-author)
- [x] `mypy companyctx tests scripts/probe_reviews.py` clean (reported by branch-author; 40 source files, no issues)
- [x] `pytest -q` — 394 tests passed (reported by branch-author)
- [x] Content scan verified: the three committed files contain no references to `noontide-projects`, `new-signal-studio`, `joel-req`, `INSUFFICIENT DATA`, partner-workflow specifics, dead `CLAUDE.md` citations, or external-LLM vendor names (Grok/Gemini/GPT attribution removed; load-bearing findings integrated on their own merits)
- [x] Docs-only + scaffold-only change — no provider behavior change, no CLI-flag change, no schema change. Existing `reviews_google_places` provider untouched.

## Notes

- ADR is **`proposed`**, not `accepted`. This PR does not authorize any code change to the reviews provider. The Slice B probe flips the ADR.
- Scope expanded mid-review from 3 finalists to 5 per two comments on #116: WebSearch + LLM parsing (agentic alternative, triggers Outcome E if it wins) and DataForSEO Google Reviews API (aggregator-family, sub-0.1¢/site pending 2026-pricing verification as the first Slice B task on that slot).
- Probe harness at `scripts/probe_reviews.py` defaults to dry-run; `--confirm-spend-usd` is a hard gate against accidental network calls.

Refs #116